### PR TITLE
Fix code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/client/src/utils/MiscUtils.ts
+++ b/client/src/utils/MiscUtils.ts
@@ -97,7 +97,7 @@ const getSystemTheme = () => {
 const checkIfNotIpAddress = (address: string) => {
   const hostname = address.split(':')[0];
   const ipv4Regex = /^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
-  const ipv6Regex = /([a-f0-9:]+:+)+[a-f0-9]+/i;
+  const ipv6Regex = /^(?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}$/i;
 
   return !ipv4Regex.test(hostname) && !ipv6Regex.test(hostname);
 }


### PR DESCRIPTION
Fixes [https://github.com/kubewall/kubewall/security/code-scanning/2](https://github.com/kubewall/kubewall/security/code-scanning/2)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we can change the pattern to ensure that it does not contain nested quantifiers that can match the same string in multiple ways. For the IPv6 regex, we can use a more precise pattern that avoids the problematic `:+` construct.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
