### PR TITLE
fix: prevent Insecure flag if certs are provided for bearer

### DIFF
--- a/backend/config/kube.go
+++ b/backend/config/kube.go
@@ -122,9 +122,17 @@ func restConfig(config api.Config, key string) (*rest.Config, error) {
 	restConfig.QPS = float32(K8SQPS)
 	restConfig.Burst = K8SBURST
 	if restConfig.BearerToken != "" {
-		restConfig.Insecure = true
+		if isTLSClientConfigEmpty(restConfig) {
+			restConfig.Insecure = true
+		}
 	}
 	return restConfig, nil
+}
+
+func isTLSClientConfigEmpty(restConfig *rest.Config) bool {
+	tlsConfig := restConfig.TLSClientConfig
+	return tlsConfig.CertFile == "" && tlsConfig.KeyFile == "" && tlsConfig.CAFile == "" &&
+		tlsConfig.CertData == nil && tlsConfig.KeyData == nil && tlsConfig.CAData == nil
 }
 
 func loadClientConfig(restConfig *rest.Config) (*Cluster, error) {

--- a/backend/config/kube_test.go
+++ b/backend/config/kube_test.go
@@ -172,3 +172,109 @@ func TestCluster_MarkAsConnected(t *testing.T) {
 		})
 	}
 }
+
+func Test_isTLSClientConfigEmpty(t *testing.T) {
+	type args struct {
+		restConfig *rest.Config
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should return false on non empty rest config",
+			args: args{
+				restConfig: &rest.Config{
+					TLSClientConfig: rest.TLSClientConfig{},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should return false on non empty rest config",
+			args: args{
+				restConfig: &rest.Config{
+					TLSClientConfig: rest.TLSClientConfig{
+						CertFile: "CertFile",
+						KeyFile:  "KeyFile",
+						CAFile:   "CAFile",
+						CertData: nil,
+						KeyData:  nil,
+						CAData:   nil,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false on non empty rest config",
+			args: args{
+				restConfig: &rest.Config{
+					TLSClientConfig: rest.TLSClientConfig{
+						CertFile: "CertFile",
+						KeyFile:  "",
+						CAFile:   "",
+						CertData: nil,
+						KeyData:  nil,
+						CAData:   nil,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false on non empty rest config",
+			args: args{
+				restConfig: &rest.Config{
+					TLSClientConfig: rest.TLSClientConfig{
+						CertFile: "",
+						KeyFile:  "",
+						CAFile:   "",
+						CertData: []byte("something"),
+						KeyData:  nil,
+						CAData:   nil,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false on non empty rest config",
+			args: args{
+				restConfig: &rest.Config{
+					TLSClientConfig: rest.TLSClientConfig{
+						CertFile: "",
+						KeyFile:  "",
+						CAFile:   "",
+						CertData: nil,
+						KeyData:  []byte("something"),
+						CAData:   nil,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "should return false on non empty rest config",
+			args: args{
+				restConfig: &rest.Config{
+					TLSClientConfig: rest.TLSClientConfig{
+						CertFile: "",
+						KeyFile:  "",
+						CAFile:   "",
+						CertData: nil,
+						KeyData:  nil,
+						CAData:   []byte("something"),
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, isTLSClientConfigEmpty(tt.args.restConfig), "isTLSClientConfigEmpty(%v)", tt.args.restConfig)
+		})
+	}
+}


### PR DESCRIPTION
This PR will prevent an auto Insecure flag if certs are provided for the bearer.
References: #25 #17