### PR TITLE
refactor: moving event processor to container

### DIFF
--- a/backend/handlers/accesscontrol/clusterroles/clusterroles.go
+++ b/backend/handlers/accesscontrol/clusterroles/clusterroles.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	rbacV1 "k8s.io/api/rbac/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewRolesHandler(c echo.Context, container container.Container) *RolesHandle
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-clusterRoleInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*rbacV1.ClusterRole](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/accesscontrol/clusterrolesbindings/clusterrolebindings.go
+++ b/backend/handlers/accesscontrol/clusterrolesbindings/clusterrolebindings.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	rbacV1 "k8s.io/api/rbac/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewClusterRoleBindingHandler(c echo.Context, container container.Container)
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-clusterRoleBinding", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*rbacV1.ClusterRoleBinding](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/accesscontrol/roles/roles.go
+++ b/backend/handlers/accesscontrol/roles/roles.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	rbacV1 "k8s.io/api/rbac/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewRolesHandler(c echo.Context, container container.Container) *RolesHandle
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-roleInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*rbacV1.Role](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/accesscontrol/rolesbindings/rolebindings.go
+++ b/backend/handlers/accesscontrol/rolesbindings/rolebindings.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	rbacV1 "k8s.io/api/rbac/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewRoleBindingHandler(c echo.Context, container container.Container) *RoleB
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-roleBindingInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*rbacV1.RoleBinding](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/accesscontrol/serviceaccounts/serviceaccounts.go
+++ b/backend/handlers/accesscontrol/serviceaccounts/serviceaccounts.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewServiceAccountsHandler(c echo.Context, container container.Container) *S
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-serviceAccountInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.ServiceAccount](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/base/base.go
+++ b/backend/handlers/base/base.go
@@ -3,7 +3,6 @@ package base
 import (
 	"fmt"
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/labstack/echo/v4"
 	"github.com/r3labs/sse/v2"
 	"k8s.io/client-go/rest"
@@ -33,7 +32,6 @@ type BaseHandler struct {
 	QueryCluster     string
 	InformerCacheKey string
 
-	Event         *event.EventProcessor
 	TransformFunc func([]any, *BaseHandler) ([]byte, error)
 }
 

--- a/backend/handlers/base/informers.go
+++ b/backend/handlers/base/informers.go
@@ -20,18 +20,18 @@ func ResourceEventHandler[T Resource](handler *BaseHandler, additionalEvents ...
 	handleEvent := func(obj any) {
 		resource := obj.(T)
 		// GetList
-		go handler.Event.AddEvent(handler.Kind, handler.processListEvents(resource.GetName()))
+		go handler.Container.EventProcessor().AddEvent(handler.Kind, handler.processListEvents(resource.GetName()))
 
 		streamName := fmt.Sprintf("%s-%s", resource.GetNamespace(), resource.GetName())
 		// GetDetails
-		go handler.Event.AddEvent(streamName, handler.processDetailsEvents(resource.GetNamespace(), resource.GetName()))
+		go handler.Container.EventProcessor().AddEvent(streamName, handler.processDetailsEvents(resource.GetNamespace(), resource.GetName()))
 
 		// GetYAML
-		go handler.Event.AddEvent(streamName+"-yaml", handler.processYAMLEvents(resource.GetNamespace(), resource.GetName()))
+		go handler.Container.EventProcessor().AddEvent(streamName+"-yaml", handler.processYAMLEvents(resource.GetNamespace(), resource.GetName()))
 
 		for _, event := range additionalEvents {
 			for key, e := range event {
-				go handler.Event.AddEvent(key, e)
+				go handler.Container.EventProcessor().AddEvent(key, e)
 			}
 		}
 	}
@@ -71,7 +71,7 @@ func (h *BaseHandler) WaitForSync(c echo.Context) {
 	err := wait.PollUntilContextCancel(c.Request().Context(), 100*time.Millisecond, true, func(context.Context) (done bool, err error) {
 		hasSynced := h.Informer.HasSynced()
 		if hasSynced {
-			h.Event.AddEvent(h.Kind, h.processListEvents(""))
+			h.Container.EventProcessor().AddEvent(h.Kind, h.processListEvents(""))
 		}
 		return hasSynced, nil
 	})

--- a/backend/handlers/config/configMaps/configMaps.go
+++ b/backend/handlers/config/configMaps/configMaps.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewConfigMapsHandler(c echo.Context, container container.Container) *Config
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-configMapInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.ConfigMap](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/horizontalPodAutoscalers/horizontalpodautoscalers.go
+++ b/backend/handlers/config/horizontalPodAutoscalers/horizontalpodautoscalers.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	autoScalingV2 "k8s.io/api/autoscaling/v2"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewHorizontalPodAutoScalerHandler(c echo.Context, container container.Conta
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-horizontalPodAutoscalerInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*autoScalingV2.HorizontalPodAutoscaler](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/leases/leases.go
+++ b/backend/handlers/config/leases/leases.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	v1 "k8s.io/api/coordination/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewLeasesHandler(c echo.Context, container container.Container) *LeasesHand
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-leaseInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*v1.Lease](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/limitRanges/limitRanges.go
+++ b/backend/handlers/config/limitRanges/limitRanges.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewLimitRangesHandler(c echo.Context, container container.Container) *Limit
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-limitRangesInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.LimitRange](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/podDisruptionBudgets/podDisruptionBudgets.go
+++ b/backend/handlers/config/podDisruptionBudgets/podDisruptionBudgets.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	policyV1 "k8s.io/api/policy/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewPodDisruptionBudgetHandler(c echo.Context, container container.Container
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-podDisruptionBudgetInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*policyV1.PodDisruptionBudget](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/priorityClasses/priorityclasses.go
+++ b/backend/handlers/config/priorityClasses/priorityclasses.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	v1 "k8s.io/api/scheduling/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewPriorityClassHandler(c echo.Context, container container.Container) *Pri
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-priorityClassInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*v1.PriorityClass](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 
 	return handler

--- a/backend/handlers/config/resourceQuotas/resourceQuotas.go
+++ b/backend/handlers/config/resourceQuotas/resourceQuotas.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewResourceQuotaHandler(c echo.Context, container container.Container) *Res
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-resourceQuotaInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.ResourceQuota](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/runtimeClasses/runtimeClasses.go
+++ b/backend/handlers/config/runtimeClasses/runtimeClasses.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	v1 "k8s.io/api/node/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewRunTimeClassHandler(c echo.Context, container container.Container) *RunT
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-runtimeClassInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*v1.RuntimeClass](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/config/secrets/secrets.go
+++ b/backend/handlers/config/secrets/secrets.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,12 @@ func NewSecretsHandler(c echo.Context, container container.Container) *SecretsHa
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-secretsInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.Secret](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
+
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/crds/crds/definitions.go
+++ b/backend/handlers/crds/crds/definitions.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"net/http"
-	"time"
 )
 
 type CRDHandler struct {
@@ -33,14 +31,13 @@ func NewCRDHandler(container container.Container, routeType base.RouteType) echo
 				QueryConfig:      config,
 				QueryCluster:     cluster,
 				InformerCacheKey: fmt.Sprintf("%s-%s-customResourceDefinitionInformer", config, cluster),
-				Event:            event.NewEventCounter(time.Millisecond * 250),
 				TransformFunc:    transformItems,
 			},
 		}
 
 		cache := base.ResourceEventHandler[*apiextensionsv1.CustomResourceDefinition](&handler.BaseHandler)
 		handler.BaseHandler.StartExtensionInformer(c, cache)
-		go handler.BaseHandler.Event.Run()
+
 		handler.BaseHandler.WaitForSync(c)
 
 		switch routeType {

--- a/backend/handlers/namespaces/namespaces.go
+++ b/backend/handlers/namespaces/namespaces.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewNamespacesHandler(c echo.Context, container container.Container) *Namesp
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-namespaceInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*v1.Namespace](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/network/endpoints/endpoints.go
+++ b/backend/handlers/network/endpoints/endpoints.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,14 +53,12 @@ func NewEndpointsHandler(c echo.Context, container container.Container) *Endpoin
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-endpointsInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 
 	cache := base.ResourceEventHandler[*v1.Endpoints](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/network/ingresses/ingresses.go
+++ b/backend/handlers/network/ingresses/ingresses.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	networkingV1 "k8s.io/api/networking/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewIngressHandler(c echo.Context, container container.Container) *IngressHa
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-IngressInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*networkingV1.Ingress](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/network/services/services.go
+++ b/backend/handlers/network/services/services.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	v1 "k8s.io/api/core/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewServicesHandler(c echo.Context, container container.Container) *Services
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-ServiceInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*v1.Service](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/nodes/nodes.go
+++ b/backend/handlers/nodes/nodes.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -52,13 +50,11 @@ func NewNodeHandler(c echo.Context, container container.Container) *NodeHandler 
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-nodeInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.Node](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/storage/persistentvolumeclaims/persistentvolumeclaims.go
+++ b/backend/handlers/storage/persistentvolumeclaims/persistentvolumeclaims.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,14 +53,12 @@ func NewPersistentVolumeClaimsHandler(c echo.Context, container container.Contai
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-persistentVolumeClaimInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 
 	cache := base.ResourceEventHandler[*coreV1.PersistentVolumeClaim](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/storage/persistentvolumes/persistentvolumes.go
+++ b/backend/handlers/storage/persistentvolumes/persistentvolumes.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewPersistentVolumeHandler(c echo.Context, container container.Container) *
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-persistentVolumeInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*coreV1.PersistentVolume](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/storage/storageclasses/storageclasses.go
+++ b/backend/handlers/storage/storageclasses/storageclasses.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	storageV1 "k8s.io/api/storage/v1"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,13 +53,11 @@ func NewStorageClassesHandler(c echo.Context, container container.Container) *St
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-storageClassInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*storageV1.StorageClass](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/workloads/cronJobs/cronJobs.go
+++ b/backend/handlers/workloads/cronJobs/cronJobs.go
@@ -4,13 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
 	batchV1 "k8s.io/api/batch/v1"
 	"net/http"
-	"time"
 )
 
 type CronJobsHandler struct {
@@ -54,13 +52,11 @@ func NewCronJobsHandler(c echo.Context, container container.Container) *CronJobs
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-cronJobInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*batchV1.CronJob](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/workloads/daemonsets/daemonsets.go
+++ b/backend/handlers/workloads/daemonsets/daemonsets.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 
@@ -56,14 +54,12 @@ func NewDaemonSetsHandler(c echo.Context, container container.Container) *Daemon
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-daemonsetInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 
 	cache := base.ResourceEventHandler[*appV1.DaemonSet](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/workloads/deployments/deployments.go
+++ b/backend/handlers/workloads/deployments/deployments.go
@@ -3,16 +3,13 @@ package deployments
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kubewall/kubewall/backend/event"
+	"github.com/kubewall/kubewall/backend/container"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/kubewall/kubewall/backend/handlers/workloads/pods"
+	"github.com/labstack/echo/v4"
 	v1 "k8s.io/api/apps/v1"
 	"net/http"
-	"time"
-
-	"github.com/kubewall/kubewall/backend/container"
-	"github.com/labstack/echo/v4"
 )
 
 const GetPods = 12
@@ -60,14 +57,12 @@ func NewDeploymentsHandler(c echo.Context, container container.Container) *Deplo
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-deploymentInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 
 	cache := base.ResourceEventHandler[*v1.Deployment](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 
 	return handler

--- a/backend/handlers/workloads/jobs/jobs.go
+++ b/backend/handlers/workloads/jobs/jobs.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/kubewall/kubewall/backend/container"
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	"github.com/labstack/echo/v4"
@@ -55,14 +53,12 @@ func NewJobsHandler(c echo.Context, container container.Container) *JobsHandler 
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-jobsInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 
 	cache := base.ResourceEventHandler[*batchV1.Job](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/workloads/pods/pods.go
+++ b/backend/handlers/workloads/pods/pods.go
@@ -74,7 +74,6 @@ func NewPodsHandler(c echo.Context, container container.Container) *PodsHandler 
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-podInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 		restConfig:        container.RestConfig(config, cluster),
@@ -92,7 +91,6 @@ func NewPodsHandler(c echo.Context, container container.Container) *PodsHandler 
 
 	cache := base.ResourceEventHandler[*v1.Pod](&handler.BaseHandler, additionalEvents...)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 
 	return handler

--- a/backend/handlers/workloads/replicaset/replicaset.go
+++ b/backend/handlers/workloads/replicaset/replicaset.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 
@@ -56,14 +54,12 @@ func NewReplicaSetHandler(c echo.Context, container container.Container) *Replic
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-replicaSetInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 
 	cache := base.ResourceEventHandler[*appV1.ReplicaSet](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/backend/handlers/workloads/statefulsets/statefulsets.go
+++ b/backend/handlers/workloads/statefulsets/statefulsets.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"time"
 
-	"github.com/kubewall/kubewall/backend/event"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
 	appV1 "k8s.io/api/apps/v1"
@@ -56,13 +54,11 @@ func NewSatefulSetHandler(c echo.Context, container container.Container) *Statef
 			QueryConfig:      config,
 			QueryCluster:     cluster,
 			InformerCacheKey: fmt.Sprintf("%s-%s-statefulSetInformer", config, cluster),
-			Event:            event.NewEventCounter(time.Millisecond * 250),
 			TransformFunc:    transformItems,
 		},
 	}
 	cache := base.ResourceEventHandler[*appV1.StatefulSet](&handler.BaseHandler)
 	handler.BaseHandler.StartInformer(c, cache)
-	go handler.BaseHandler.Event.Run()
 	handler.BaseHandler.WaitForSync(c)
 	return handler
 }

--- a/charts/kubewall/values.yaml
+++ b/charts/kubewall/values.yaml
@@ -64,10 +64,10 @@ service:
 resources:
   limits:
     cpu: 100m  # Maximum CPU limit (100 milli-CPU)
-    memory: 128Mi  # Maximum memory limit (128 MiB)
+    memory: 256Mi  # Maximum memory limit (128 MiB)
   requests:
     cpu: 100m  # Minimum CPU request (100 milli-CPU)
-    memory: 128Mi  # Minimum memory request (128 MiB)
+    memory: 256Mi  # Minimum memory request (128 MiB)
 
 # Persistent volume claim (PVC) for Kubewall data storage
 pvc:


### PR DESCRIPTION
moving the event processor to the container will prevent the creation of a new instance of the event processor on every page refresh.