### PR TITLE
chore: use latest stable kubectl for docker images

### DIFF
--- a/.goreleaser.Dockerfile
+++ b/.goreleaser.Dockerfile
@@ -1,11 +1,8 @@
 # Stage 1: Build the Go application and download kubectl for the correct architecture
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.21 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.23 as builder
 
 WORKDIR /app
 ARG TARGETARCH
-
-# Set the kubectl version
-ENV KUBECTL_VERSION=v1.31.0
 
 # Install kubectl for the correct architecture
 # Using TARGETARCH to ensure the right binary is downloaded
@@ -13,10 +10,10 @@ RUN ARCH=$(case $TARGETARCH in \
     amd64) echo "amd64" ;; \
     arm64) echo "arm64" ;; \
     esac) \
-    && curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
+    && curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x kubectl
 
-# Stage 2: Create the final distroless image with the compiled binaries
+# Stage 2: Create the final scratch image with the compiled binaries
 FROM --platform=$BUILDPLATFORM scratch
 COPY --from=builder /app/kubectl /usr/bin/kubectl
 COPY kubewall /usr/bin/kubewall


### PR DESCRIPTION
This PR update docker image 
* It will now use the latest stable kubectl from k8s.io
* Updates builder image to `golang:1.23`