### PR TITLE
refactor: removing extra call to Discovery().ServerGroups()

### DIFF
--- a/backend/routes/middleware/ClusterCacheMiddleware.go
+++ b/backend/routes/middleware/ClusterCacheMiddleware.go
@@ -19,15 +19,10 @@ func ClusterCacheMiddleware(container container.Container) echo.MiddlewareFunc {
 			cluster := c.QueryParam("cluster")
 
 			allResourcesKey := fmt.Sprintf(helpers.AllResourcesCacheKeyFormat, config, cluster)
-			metricAPIAvailableKey := fmt.Sprintf(helpers.IsMetricServerAvailableCacheKeyFormat, config, cluster)
 
 			conn := container.Config().KubeConfig[config].Clusters[cluster]
 			if !conn.IsConnected() {
 				conn.MarkAsConnected()
-			}
-
-			if !container.Cache().Has(metricAPIAvailableKey) {
-				helpers.CacheIfIsMetricsAPIAvailable(container, config, cluster)
 			}
 
 			if !container.Cache().Has(allResourcesKey) {


### PR DESCRIPTION
This PR removes extra call to Discovery().ServerGroups() for checking if "metrics.k8s.io"  ( Metric Serer ) is present on the cluster.  