### PR TITLE
fix: updating default for flags

### DIFF
--- a/backend/cmd/cmd.go
+++ b/backend/cmd/cmd.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/kubewall/kubewall/backend/config"
 	"github.com/kubewall/kubewall/backend/container"
 	"github.com/kubewall/kubewall/backend/routes"
@@ -9,15 +11,14 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func init() {
 	rootCmd.PersistentFlags().String("certFile", "", "absolute path to certificate file")
 	rootCmd.PersistentFlags().String("keyFile", "", "absolute path to key file")
 	rootCmd.PersistentFlags().StringP("port", "p", ":7080", "port to listen on")
-	rootCmd.PersistentFlags().Int("k8s-client-qps", 50, "maximum QPS to the master from client")
-	rootCmd.PersistentFlags().Int("k8s-client-burst", 50, "Maximum burst for throttle")
+	rootCmd.PersistentFlags().Int("k8s-client-qps", 100, "maximum QPS to the master from client")
+	rootCmd.PersistentFlags().Int("k8s-client-burst", 200, "Maximum burst for throttle")
 	rootCmd.PersistentFlags().Bool("no-open-browser", false, "Do not open the default browser")
 }
 

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -8,10 +8,8 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
-var (
-	K8SQPS   = 100
-	K8SBURST = 200
-)
+var K8SQPS int
+var K8SBURST int
 
 const (
 	defaultKubeConfigDir = ".kube"
@@ -44,9 +42,9 @@ func NewEnv() *Env {
 	return &env
 }
 
-func NewAppConfig(version string, k8sqps, k8sburst int) *AppConfig {
-	K8SQPS = k8sqps
-	K8SBURST = k8sburst
+func NewAppConfig(version string, k8sClientQPS, k8sClientBurst int) *AppConfig {
+	K8SQPS = k8sClientQPS
+	K8SBURST = k8sClientBurst
 	return &AppConfig{
 		Version:    version,
 		KubeConfig: make(map[string]*KubeConfigInfo),

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -2,10 +2,11 @@ package config
 
 import (
 	"fmt"
-	"k8s.io/client-go/util/homedir"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/client-go/util/homedir"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This PR updates the default values flag values for `k8s-client-qps` and `k8s-client-burst` for cli