### PR TITLE
fix: sort crds list by group name

### DIFF
--- a/backend/handlers/crds/crds/transformer.go
+++ b/backend/handlers/crds/crds/transformer.go
@@ -45,7 +45,7 @@ func TransformCRD(definitions []apiextensionsv1.CustomResourceDefinition) []Cust
 	}
 
 	sort.Slice(list, func(i, j int) bool {
-		return natural.Less(list[i].Name, list[j].Name)
+		return natural.Less(list[i].Spec.Group, list[j].Spec.Group)
 	})
 
 	return list


### PR DESCRIPTION
This PR updates the sorting of CARDs by group name. In that way sidebar is alphabetical order.