### PR TITLE
fix: correct certificate authentication TLS configuration

### DIFF
--- a/backend/handlers/app/config.go
+++ b/backend/handlers/app/config.go
@@ -81,14 +81,32 @@ func (h *AppConfigHandler) PostCertificate(c echo.Context) error {
 	name := strings.TrimSpace(c.FormValue("name"))
 	cert := strings.TrimSpace(c.FormValue("clientCertData"))
 	key := strings.TrimSpace(c.FormValue("clientKeyData"))
+	tlsMode := strings.TrimSpace(c.FormValue("tlsMode"))
+	caCert := strings.TrimSpace(c.FormValue("caCertData"))
 
 	if serverIP == "" || name == "" || cert == "" || key == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "Missing required fields: serverIP, name, clientCertData, or clientKeyData")
 	}
 
+	// Default to system mode if not specified
+	if tlsMode == "" {
+		tlsMode = "system"
+	}
+
+	// Validate: if custom mode, CA cert is required
+	if tlsMode == "custom" && caCert == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "CA certificate required for custom TLS mode")
+	}
+
 	encodedCert := base64.StdEncoding.EncodeToString([]byte(cert))
 	encodedKey := base64.StdEncoding.EncodeToString([]byte(key))
-	kubeconfig := generateCertificateConfig(serverIP, name, encodedCert, encodedKey)
+
+	var encodedCaCert string
+	if caCert != "" {
+		encodedCaCert = base64.StdEncoding.EncodeToString([]byte(caCert))
+	}
+
+	kubeconfig := generateCertificateConfig(serverIP, name, encodedCert, encodedKey, encodedCaCert, tlsMode)
 
 	uuidStr, path := generateConfigPath()
 	if err := writeKubeconfigToFile(path, kubeconfig); err != nil {
@@ -161,14 +179,30 @@ users:
 `, serverIP, name, name, name, name, name, name, token)
 }
 
-func generateCertificateConfig(serverIP, name, certData, keyData string) string {
+func generateCertificateConfig(serverIP, name, certData, keyData, caCertData, tlsMode string) string {
+	var clusterBlock string
+
+	switch tlsMode {
+	case "insecure":
+		clusterBlock = fmt.Sprintf(`- cluster:
+    insecure-skip-tls-verify: true
+    server: %s
+  name: %s`, serverIP, name)
+	case "custom":
+		clusterBlock = fmt.Sprintf(`- cluster:
+    certificate-authority-data: %s
+    server: %s
+  name: %s`, caCertData, serverIP, name)
+	default: // "system" - use OS CA bundle
+		clusterBlock = fmt.Sprintf(`- cluster:
+    server: %s
+  name: %s`, serverIP, name)
+	}
+
 	return fmt.Sprintf(`apiVersion: v1
 kind: Config
 clusters:
-- cluster:
-    certificate-authority-data: %s
-    server: %s
-  name: %s
+%s
 contexts:
 - context:
     cluster: %s
@@ -180,5 +214,5 @@ users:
   user:
     client-certificate-data: %s
     client-key-data: %s
-`, certData, serverIP, name, name, name, name, name, name, certData, keyData)
+`, clusterBlock, name, name, name, name, name, certData, keyData)
 }

--- a/client/src/types/KubeConfiguration/addConfig.d.ts
+++ b/client/src/types/KubeConfiguration/addConfig.d.ts
@@ -9,6 +9,8 @@ type CertificateConfig = {
   apiServer: string;
   certificate: string;
   certificateKey: string;
+  tlsMode: 'system' | 'custom' | 'insecure';
+  caCertificate: string;
 };
 
 type KubeconfigFileConfig = {


### PR DESCRIPTION
## Summary

The certificate authentication feature incorrectly used the client certificate as the CA certificate in the generated kubeconfig, causing TLS verification failures when connecting to clusters.

This PR fixes the bug by:
- Adding a TLS verification mode dropdown with three explicit options
- Properly separating CA certificate from client certificate
- Allowing users to choose their security preference

## Changes

### Frontend
- Added TLS Verification dropdown (`system` | `custom` | `insecure`)
- Added conditional CA Certificate textarea (visible when "custom" mode selected)
- Added warning message when "insecure" mode is selected
- Updated form validation to require CA cert when custom mode is selected

### Backend
- Updated `PostCertificate` handler to parse `tlsMode` and `caCertData` parameters
- Rewrote `generateCertificateConfig` to handle all three TLS modes:
  - `system`: No TLS fields (uses OS CA bundle)
  - `custom`: Uses provided CA certificate
  - `insecure`: Sets `insecure-skip-tls-verify: true`

## Test Plan

- [ ] Test "Use system certificates" mode - generates kubeconfig without TLS fields
- [x] Test "Use custom CA certificate" mode - generates kubeconfig with `certificate-authority-data`
- [x] Test "Skip verification (insecure)" mode - generates kubeconfig with `insecure-skip-tls-verify: true`
- [x] Verify warning appears when insecure mode is selected
- [x] Verify Save button is disabled when custom mode is selected without CA cert