### PR TITLE
fix: search bar now matches kubeconfig file names

### DIFF
--- a/client/src/components/app/KubeConfiguration/index.tsx
+++ b/client/src/components/app/KubeConfiguration/index.tsx
@@ -49,18 +49,33 @@ export function KubeConfiguration() {
       setFilteredClusters(clusters);
     } else {
       const res: Clusters = { kubeConfigs: {}, version: '' };
-      Object.keys(clusters.kubeConfigs).map((key) => {
-        Object.keys(clusters.kubeConfigs[key].clusters).map((skey) => {
-          if (skey.toLowerCase().includes(searchText.toLowerCase())) {
+      const searchLower = searchText.toLowerCase();
+
+      Object.keys(clusters.kubeConfigs).forEach((key) => {
+        const configNameMatches = key.toLowerCase().includes(searchLower);
+
+        if (configNameMatches) {
+          // If kubeconfig name matches, include entire config with all clusters
+          res.kubeConfigs[key] = clusters.kubeConfigs[key];
+        } else {
+          // Otherwise, check individual context names
+          const matchingClusters: typeof clusters.kubeConfigs[typeof key]['clusters'] = {};
+
+          Object.keys(clusters.kubeConfigs[key].clusters).forEach((skey) => {
+            if (skey.toLowerCase().includes(searchLower)) {
+              matchingClusters[skey] = clusters.kubeConfigs[key].clusters[skey];
+            }
+          });
+
+          if (Object.keys(matchingClusters).length > 0) {
             res.kubeConfigs[key] = {
               ...clusters.kubeConfigs[key],
-              clusters: {
-                [skey]: clusters.kubeConfigs[key].clusters[skey]
-              }
+              clusters: matchingClusters
             };
           }
-        });
+        }
       });
+
       setFilteredClusters(res);
     }
   };


### PR DESCRIPTION
## Summary

The search/filter bar in the KubeConfiguration page only searched **context names** inside kubeconfig files, not the **kubeconfig file name** itself. This caused confusion when users added a config with a specific name (e.g., "cks-01") but couldn't find it by searching that name.

### Changes
- Modified `onSearch` function in `client/src/components/app/KubeConfiguration/index.tsx`
- Search now matches if either:
  - The kubeconfig file name contains the search text, OR
  - Any context name inside the kubeconfig contains the search text
- When kubeconfig name matches, all its contexts are included in results
- Also fixed a bug where only the last matching context was kept (now all matching contexts are included)

## Test Plan

- [ ] Add a kubeconfig with a custom name (e.g., "my-cluster")
- [ ] Search for the kubeconfig name → should show results
- [ ] Search for a context name inside a kubeconfig → should still work
- [ ] Clear search → should show all configs
- [ ] Works for configs added via file upload, bearer token, and certificate methods