### PR TITLE
fix: log window overflow and add infinite scroll for older logs

### DIFF
--- a/backend/handlers/workloads/pods/logs.go
+++ b/backend/handlers/workloads/pods/logs.go
@@ -5,11 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/charmbracelet/log"
+	"github.com/labstack/echo/v4"
 	"github.com/r3labs/sse/v2"
 	v1 "k8s.io/api/core/v1"
 )
@@ -76,34 +80,9 @@ func (h *PodsHandler) fetchLogs(ctx context.Context, namespace, podName, contain
 }
 
 func (h *PodsHandler) publishLogsToSSE(ctx context.Context, name, namespace, container, allContainers, streamKey string, sseServer *sse.Server) (error, bool) {
-	isAllContainers := strings.EqualFold(allContainers, "true")
-
-	var containerNames []string
-
-	if isAllContainers {
-		podObj, _, err := h.BaseHandler.Informer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
-		if err != nil {
-			return err, true
-		}
-		if podObj == nil {
-			log.Error("pod not found in store", "namespace", namespace, "pod", name)
-			return fmt.Errorf("pod %s/%s not found in store", namespace, name), true
-		}
-		pod, ok := podObj.(*v1.Pod)
-		if !ok {
-			log.Error("failed to type assert pod object", "namespace", namespace, "pod", name)
-			return fmt.Errorf("failed to type assert pod object %s/%s", namespace, name), true
-		}
-		// Include init containers
-		for _, initContainer := range pod.Spec.InitContainers {
-			containerNames = append(containerNames, initContainer.Name)
-		}
-		// Include regular containers
-		for _, logContainer := range pod.Spec.Containers {
-			containerNames = append(containerNames, logContainer.Name)
-		}
-	} else {
-		containerNames = []string{container}
+	containerNames, err := h.getContainerNames(namespace, name, container, allContainers)
+	if err != nil {
+		return err, true
 	}
 
 	logsChannel := make(chan LogMessage, 100)
@@ -133,4 +112,160 @@ func (h *PodsHandler) publishLogsToSSE(ctx context.Context, name, namespace, con
 	}
 
 	return nil, false
+}
+
+const timestampLayout = "2006-01-02 15:04:05.000Z"
+
+type HistoryResponse struct {
+	Logs    []LogMessage `json:"logs"`
+	HasMore bool         `json:"hasMore"`
+}
+
+func (h *PodsHandler) getContainerNames(namespace, name, container, allContainers string) ([]string, error) {
+	if !strings.EqualFold(allContainers, "true") {
+		return []string{container}, nil
+	}
+	podObj, _, err := h.BaseHandler.Informer.GetStore().GetByKey(fmt.Sprintf("%s/%s", namespace, name))
+	if err != nil {
+		return nil, err
+	}
+	if podObj == nil {
+		return nil, fmt.Errorf("pod %s/%s not found in store", namespace, name)
+	}
+	pod, ok := podObj.(*v1.Pod)
+	if !ok {
+		return nil, fmt.Errorf("failed to type assert pod object %s/%s", namespace, name)
+	}
+	var names []string
+	for _, c := range pod.Spec.InitContainers {
+		names = append(names, c.Name)
+	}
+	for _, c := range pod.Spec.Containers {
+		names = append(names, c.Name)
+	}
+	return names, nil
+}
+
+func (h *PodsHandler) fetchHistoricalLogs(ctx context.Context, namespace, podName, containerName string, tailLines int64) []LogMessage {
+	podLogOptions := &v1.PodLogOptions{
+		Container:  containerName,
+		Timestamps: true,
+		Follow:     false,
+		TailLines:  &tailLines,
+	}
+	req := h.clientSet.CoreV1().Pods(namespace).GetLogs(podName, podLogOptions)
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		log.Error("failed to open historical log stream", "pod", podName, "container", containerName, "err", err)
+		return nil
+	}
+	defer podLogs.Close()
+
+	var result []LogMessage
+	scanner := bufio.NewScanner(podLogs)
+	scanner.Buffer(make([]byte, 0, maxLogLineSize), maxLogLineSize)
+
+	for scanner.Scan() {
+		logLine := scanner.Text()
+		parts := strings.Split(logLine, " ")
+		if len(parts) == 0 {
+			continue
+		}
+		parseTime, err := time.Parse(time.RFC3339Nano, parts[0])
+		if err != nil {
+			continue
+		}
+		result = append(result, LogMessage{
+			ContainerName: containerName,
+			Timestamp:     parseTime.Format(timestampLayout),
+			Log:           strings.Join(parts[1:], " "),
+		})
+	}
+	return result
+}
+
+func (h *PodsHandler) GetLogHistory(c echo.Context) error {
+	ctx := c.Request().Context()
+	name := c.Param("name")
+	namespace := c.QueryParam("namespace")
+	containerName := c.QueryParam("container")
+	allContainers := c.QueryParam("all-containers")
+	beforeStr := c.QueryParam("before")
+	batchSizeStr := c.QueryParam("batchSize")
+
+	if beforeStr == "" {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "before parameter is required"})
+	}
+
+	beforeTime, err := time.Parse(timestampLayout, beforeStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid before timestamp"})
+	}
+
+	batchSize := int64(500)
+	if batchSizeStr != "" {
+		if parsed, err := strconv.ParseInt(batchSizeStr, 10, 64); err == nil && parsed > 0 {
+			batchSize = parsed
+		}
+	}
+
+	containerNames, err := h.getContainerNames(namespace, name, containerName, allContainers)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+	}
+
+	// Fetch with escalating tailLines until we find enough older logs
+	var allLogs []LogMessage
+	hasMore := true
+	tailLines := batchSize * 3
+	maxTailLines := int64(50000)
+
+	for tailLines <= maxTailLines {
+		allLogs = nil
+		for _, cn := range containerNames {
+			logs := h.fetchHistoricalLogs(ctx, namespace, name, cn, tailLines)
+			allLogs = append(allLogs, logs...)
+		}
+
+		// Filter to logs before the cutoff
+		var filtered []LogMessage
+		for _, l := range allLogs {
+			t, err := time.Parse(timestampLayout, l.Timestamp)
+			if err != nil {
+				continue
+			}
+			if t.Before(beforeTime) {
+				filtered = append(filtered, l)
+			}
+		}
+
+		if len(filtered) >= int(batchSize) || tailLines >= maxTailLines {
+			// Sort by timestamp
+			sort.Slice(filtered, func(i, j int) bool {
+				return filtered[i].Timestamp < filtered[j].Timestamp
+			})
+			// Take the last batchSize entries (most recent before cutoff)
+			if int64(len(filtered)) > batchSize {
+				filtered = filtered[len(filtered)-int(batchSize):]
+				hasMore = true
+			} else {
+				// We fetched everything up to maxTailLines and got fewer than batchSize
+				hasMore = tailLines < maxTailLines && int64(len(allLogs)) >= tailLines
+			}
+			return c.JSON(http.StatusOK, HistoryResponse{Logs: filtered, HasMore: hasMore})
+		}
+
+		// Not enough older logs found, try with more
+		if int64(len(allLogs)) < tailLines {
+			// We got fewer lines than requested — there are no more logs
+			sort.Slice(filtered, func(i, j int) bool {
+				return filtered[i].Timestamp < filtered[j].Timestamp
+			})
+			return c.JSON(http.StatusOK, HistoryResponse{Logs: filtered, HasMore: false})
+		}
+
+		tailLines *= 2
+	}
+
+	return c.JSON(http.StatusOK, HistoryResponse{Logs: nil, HasMore: false})
 }

--- a/backend/handlers/workloads/pods/logs.go
+++ b/backend/handlers/workloads/pods/logs.go
@@ -194,12 +194,12 @@ func (h *PodsHandler) GetLogHistory(c echo.Context) error {
 	batchSizeStr := c.QueryParam("batchSize")
 
 	if beforeStr == "" {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "before parameter is required"})
+		return echo.NewHTTPError(http.StatusBadRequest, "before parameter is required")
 	}
 
 	beforeTime, err := time.Parse(timestampLayout, beforeStr)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, map[string]string{"error": "invalid before timestamp"})
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid before timestamp")
 	}
 
 	batchSize := int64(500)
@@ -211,7 +211,7 @@ func (h *PodsHandler) GetLogHistory(c echo.Context) error {
 
 	containerNames, err := h.getContainerNames(namespace, name, containerName, allContainers)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, map[string]string{"error": err.Error()})
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
 	}
 
 	// Fetch with escalating tailLines until we find enough older logs

--- a/backend/handlers/workloads/pods/pods.go
+++ b/backend/handlers/workloads/pods/pods.go
@@ -24,6 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
+const (
+	GetLogHistory base.RouteType = 14
+)
+
 type PodsHandler struct {
 	BaseHandler       base.BaseHandler
 	clientSet         *kubernetes.Clientset
@@ -48,6 +52,8 @@ func NewPodsRouteHandler(container container.Container, routeType base.RouteType
 			return handler.BaseHandler.Delete(c)
 		case base.GetLogs:
 			return handler.GetLogs(c)
+		case GetLogHistory:
+			return handler.GetLogHistory(c)
 		default:
 			return echo.NewHTTPError(http.StatusInternalServerError, "Unknown route type")
 		}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -250,6 +250,7 @@ func workloadRoutes(e *echo.Echo, appContainer container.Container) {
 	e.GET("api/v1/pods/:name", pods.NewPodsRouteHandler(appContainer, base.GetDetails)).Name = "podsDetails"
 	e.GET("api/v1/pods/:name/yaml", pods.NewPodsRouteHandler(appContainer, base.GetYaml)).Name = "podsYaml"
 	e.GET("api/v1/pods/:name/logs", pods.NewPodsRouteHandler(appContainer, base.GetLogs)).Name = "podsLogs"
+	e.GET("api/v1/pods/:name/logs/history", pods.NewPodsRouteHandler(appContainer, pods.GetLogHistory)).Name = "podsLogsHistory"
 	e.GET("api/v1/pods/:name/events", pods.NewPodsRouteHandler(appContainer, base.GetEvents)).Name = "podsEvents"
 	e.DELETE("api/v1/pods", pods.NewPodsRouteHandler(appContainer, base.Delete)).Name = "podsDelete"
 

--- a/client/src/components/app/Common/Details/index.tsx
+++ b/client/src/components/app/Common/Details/index.tsx
@@ -128,7 +128,7 @@ const KwDetails = () => {
         </span>
       </div>
 
-      <div className="h-screen flex-1 flex-col space-y-2 pt-0 p-2 md:flex" style={{ width: `calc(100vw - ${(getMaxWidth())}px)` }}>
+      <div className="h-screen flex flex-col space-y-2 pt-0 p-2 overflow-hidden" style={{ width: `calc(100vw - ${(getMaxWidth())}px)` }}>
         {
           resourceInitialData?.loading ? <Loader /> :
             <>
@@ -215,8 +215,8 @@ const KwDetails = () => {
 
               </div>
               {resourceData &&
-                <Tabs defaultValue='overview'>
-                  <TabsList className="grid w-full grid-cols-6 md:grid-cols-6 sm:grid-cols-4 mb-2">
+                <Tabs defaultValue='overview' className="flex flex-col flex-1 min-h-0">
+                  <TabsList className="grid w-full grid-cols-6 md:grid-cols-6 sm:grid-cols-4 mb-2 shrink-0">
                     <TabsTrigger value='overview' autoFocus={true}>Overview</TabsTrigger>
                     <TabsTrigger value='yaml'>YAML</TabsTrigger>
                     <TabsTrigger value='events'>Events</TabsTrigger>
@@ -225,11 +225,12 @@ const KwDetails = () => {
 
                   <ResizablePanelGroup
                     direction="horizontal"
+                    className="flex-1 min-h-0"
                   >
                     {
                       !fullScreen &&
-                      <ResizablePanel className="border-t-0 mr-2 min-w-80 !overflow-auto" id="details" order={1} defaultSize={showChat ? 55 : 100}>
-                        <TabsContent className="mt-0" value='overview'>
+                      <ResizablePanel className="border-t-0 mr-2 min-w-80 overflow-hidden" id="details" order={1} defaultSize={showChat ? 55 : 100}>
+                        <TabsContent className="mt-0 h-full overflow-auto" value='overview'>
                           <Overview
                             details={[resourceData.detailCard]}
                             lableConditions={resourceData.lableConditionsCardDetails}
@@ -237,7 +238,7 @@ const KwDetails = () => {
                             miscComponent={resourceData.miscComponent}
                           />
                         </TabsContent>
-                        <TabsContent className="mt-0" value='yaml'>
+                        <TabsContent className="mt-0 h-full overflow-auto" value='yaml'>
                           <YamlEditor
                             name={resourcename}
                             configName={config}
@@ -247,7 +248,7 @@ const KwDetails = () => {
                             extraQuery={resourceInitialData.label === 'Custom Resources' ? '&' + new URLSearchParams({ group, kind, resource, version }).toString() : ''}
                           />
                         </TabsContent>
-                        <TabsContent className="mt-0" value='events'>
+                        <TabsContent className="mt-0 h-full overflow-auto" value='events'>
                           <Events
                             name={resourcename}
                             configName={config}
@@ -258,7 +259,7 @@ const KwDetails = () => {
                         </TabsContent>
                         {
                           resourceInitialData.label.toLowerCase() === PODS_ENDPOINT &&
-                          <TabsContent className="mt-0" value='logs'>
+                          <TabsContent className="mt-0 h-full overflow-hidden" value='logs'>
                             <PodLogs
                               name={podDetails?.metadata?.name}
                               configName={config}

--- a/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
@@ -31,7 +31,6 @@ type SocketLogsProps = {
 }
 
 const RESET = '\x1b[0m';
-const DIM = '\x1b[2m';
 const SEP = '  ● ';
 
 const COLOR_TIMESTAMP_DARK = '\x1b[38;5;242m';

--- a/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useRef } from "react";
+import { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { PodDetailsSpec, PodSocketResponse } from "@/types";
 import { getColorForContainerName, getEventStreamUrl } from "@/utils";
 
@@ -6,6 +6,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { Terminal } from "@xterm/xterm";
 import XtermTerminal from "../Xtrem";
 import { useEventSource } from "@/components/app/Common/Hooks/EventSource";
+import { fetchLogHistory } from "@/data/Workloads/Pods/fetchLogHistory";
 
 export type SocketLogsHandle = {
   replayFiltered: (term: string) => void;
@@ -81,6 +82,11 @@ export function SocketLogs({
   const filterModeRef = useRef(filterMode);
   const filterTermRef = useRef(filterTerm);
   const isDarkRef = useRef(isDark);
+  const isLoadingHistoryRef = useRef(false);
+  const hasMoreHistoryRef = useRef(true);
+  const isRenderingRef = useRef(false);
+  const pendingLogsRef = useRef<PodSocketResponse[]>([]);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
 
   filterModeRef.current = filterMode;
   filterTermRef.current = filterTerm;
@@ -157,6 +163,84 @@ export function SocketLogs({
     onCountChange(allLogsRef.current.length, allLogsRef.current.length);
   };
 
+  const replayWithScrollRestore = (prependedCount: number) => {
+    if (!xterm.current) return;
+    const term = xterm.current;
+    const currentTopLine = term.buffer.active.viewportY;
+
+    isRenderingRef.current = true;
+    term.clear();
+    rowIndexRef.current = 0;
+
+    if (filterModeRef.current && filterTermRef.current.trim()) {
+      const matched = allLogsRef.current.filter((m) => matchesTerm(m.log, filterTermRef.current));
+      matched.forEach((m) => {
+        renderLine(m, rowIndexRef.current);
+        rowIndexRef.current++;
+      });
+      visibleCountRef.current = matched.length;
+      onCountChange(allLogsRef.current.length, matched.length);
+    } else {
+      allLogsRef.current.forEach((m) => {
+        renderLine(m, rowIndexRef.current);
+        rowIndexRef.current++;
+      });
+      visibleCountRef.current = allLogsRef.current.length;
+      onCountChange(allLogsRef.current.length, allLogsRef.current.length);
+    }
+
+    // Restore scroll position accounting for prepended lines
+    requestAnimationFrame(() => {
+      term.scrollToLine(currentTopLine + prependedCount);
+      isRenderingRef.current = false;
+
+      // Flush any logs that arrived during rendering
+      const pending = pendingLogsRef.current.splice(0);
+      pending.forEach((m) => printLogLine(m));
+    });
+  };
+
+  const handleScrollToTop = useCallback(async () => {
+    if (isLoadingHistoryRef.current || !hasMoreHistoryRef.current) return;
+    if (allLogsRef.current.length === 0) return;
+    if (allLogsRef.current.length > 45000) return; // xterm scrollback limit safety
+
+    isLoadingHistoryRef.current = true;
+    setIsLoadingHistory(true);
+
+    try {
+      const oldestLog = allLogsRef.current.find(l => l.timestamp);
+      if (!oldestLog?.timestamp) return;
+
+      const response = await fetchLogHistory(pod, {
+        namespace,
+        config: configName,
+        cluster: clusterName,
+        container: containerName || undefined,
+        allContainers: !containerName,
+        before: oldestLog.timestamp,
+        batchSize: 500,
+      });
+
+      if (response.logs.length === 0) {
+        hasMoreHistoryRef.current = false;
+        return;
+      }
+
+      hasMoreHistoryRef.current = response.hasMore;
+
+      const prependedCount = response.logs.length;
+      allLogsRef.current = [...response.logs, ...allLogsRef.current];
+
+      replayWithScrollRestore(prependedCount);
+    } catch (err) {
+      // Silently fail — user can retry by scrolling up again
+    } finally {
+      isLoadingHistoryRef.current = false;
+      setIsLoadingHistory(false);
+    }
+  }, [pod, namespace, configName, clusterName, containerName]);
+
   socketLogsRef.current = { replayFiltered, replayAll, getTerminal: () => xterm.current };
 
   // Replay on terminal resize so alt-row padding recalculates with the new col width.
@@ -189,6 +273,10 @@ export function SocketLogs({
   }, [isDark]);
 
   const printLogLine = (message: PodSocketResponse) => {
+    if (isRenderingRef.current) {
+      pendingLogsRef.current.push(message);
+      return;
+    }
     allLogsRef.current.push(message);
     const total = allLogsRef.current.length;
     if (filterModeRef.current && !matchesTerm(message.log, filterTermRef.current)) {
@@ -210,6 +298,12 @@ export function SocketLogs({
     }
   };
 
+  // Reset history state when container changes
+  useEffect(() => {
+    hasMoreHistoryRef.current = true;
+    isLoadingHistoryRef.current = false;
+  }, [containerName]);
+
   useEventSource({
     url: getEventStreamUrl(`pods/${pod}/logs`, {
       namespace,
@@ -227,6 +321,8 @@ export function SocketLogs({
         xterm={xterm}
         searchAddonRef={searchAddonRef}
         updateLogs={updateLogs}
+        onScrollToTop={handleScrollToTop}
+        isLoadingHistory={isLoadingHistory}
       />
     </div>
   );

--- a/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
@@ -221,7 +221,7 @@ export function SocketLogs({
   });
 
   return (
-    <div ref={logContainerRef} className="m-2 h-full">
+    <div ref={logContainerRef} className="m-2 flex-1 min-h-0">
       <XtermTerminal
         containerNameProp={containerName}
         xterm={xterm}

--- a/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/SocketLogs/index.tsx
@@ -85,6 +85,7 @@ export function SocketLogs({
   const hasMoreHistoryRef = useRef(true);
   const isRenderingRef = useRef(false);
   const pendingLogsRef = useRef<PodSocketResponse[]>([]);
+  const isAtBottomRef = useRef(true);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
 
   filterModeRef.current = filterMode;
@@ -271,12 +272,21 @@ export function SocketLogs({
     }
   }, [isDark]);
 
+  const MAX_BUFFER = 50000;
+  const TRIM_TO = 45000;
+
   const printLogLine = (message: PodSocketResponse) => {
     if (isRenderingRef.current) {
       pendingLogsRef.current.push(message);
       return;
     }
     allLogsRef.current.push(message);
+
+    // Trim oldest logs only when user is following live (at bottom)
+    if (isAtBottomRef.current && allLogsRef.current.length > MAX_BUFFER) {
+      allLogsRef.current = allLogsRef.current.slice(-TRIM_TO);
+    }
+
     const total = allLogsRef.current.length;
     if (filterModeRef.current && !matchesTerm(message.log, filterTermRef.current)) {
       onCountChange(total, visibleCountRef.current);
@@ -322,6 +332,7 @@ export function SocketLogs({
         updateLogs={updateLogs}
         onScrollToTop={handleScrollToTop}
         isLoadingHistory={isLoadingHistory}
+        isAtBottomRef={isAtBottomRef}
       />
     </div>
   );

--- a/client/src/components/app/MiscDetailsContainer/Logs/Xtrem.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/Xtrem.tsx
@@ -1,9 +1,9 @@
 import '@xterm/xterm/css/xterm.css';
 
-import { MutableRefObject, useEffect, useRef, useState } from 'react';
+import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { ChevronsDown } from 'lucide-react';
+import { ChevronsDown, Loader2 } from 'lucide-react';
 import { FitAddon } from '@xterm/addon-fit';
 import { PodSocketResponse } from '@/types';
 import { SearchAddon } from '@xterm/addon-search';
@@ -18,6 +18,8 @@ type XtermProp = {
   xterm: MutableRefObject<Terminal | null>;
   searchAddonRef: MutableRefObject<SearchAddon | null>;
   onReady?: () => void;
+  onScrollToTop?: () => void;
+  isLoadingHistory?: boolean;
 };
 
 const DARK_THEME = {
@@ -70,7 +72,7 @@ const LIGHT_THEME = {
   brightWhite: '#1e1e1e',
 };
 
-const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, onReady }: XtermProp) => {
+const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, onReady, onScrollToTop, isLoadingHistory }: XtermProp) => {
   const dispatch = useAppDispatch();
   const terminalRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -91,6 +93,15 @@ const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, o
   }, [containerNameProp]);
 
   const scrollToBottom = () => xterm.current?.scrollToBottom();
+  const scrollToTopDebounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleScrollToTopDebounced = useCallback(() => {
+    if (!onScrollToTop) return;
+    if (scrollToTopDebounce.current) clearTimeout(scrollToTopDebounce.current);
+    scrollToTopDebounce.current = setTimeout(() => {
+      onScrollToTop();
+    }, 300);
+  }, [onScrollToTop]);
 
   useEffect(() => {
     if (!terminalRef.current) return;
@@ -138,10 +149,14 @@ const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, o
 
     const viewport = terminalRef.current.querySelector('.xterm-viewport') as HTMLElement | null;
     const checkScroll = () => {
-      if (viewport && viewport.clientHeight + viewport.scrollTop < viewport.scrollHeight - 4) {
+      if (!viewport) return;
+      if (viewport.clientHeight + viewport.scrollTop < viewport.scrollHeight - 4) {
         setShowScrollDown(true);
       } else {
         setShowScrollDown(false);
+      }
+      if (viewport.scrollTop <= 0) {
+        handleScrollToTopDebounced();
       }
     };
     viewport?.addEventListener('scroll', checkScroll, { passive: true });
@@ -151,12 +166,19 @@ const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, o
       window.removeEventListener('resize', handleResize);
       resizeObserver.disconnect();
       viewport?.removeEventListener('scroll', checkScroll);
+      if (scrollToTopDebounce.current) clearTimeout(scrollToTopDebounce.current);
       dispatch(clearLogs());
     };
   }, []);
 
   return (
     <div ref={containerRef} className="w-full h-full relative">
+      {isLoadingHistory && (
+        <div className="absolute top-0 left-0 right-0 z-10 flex items-center justify-center py-1 bg-muted/80 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 mr-1.5 animate-spin" />
+          Loading older logs...
+        </div>
+      )}
       {showScrollDown && (
         <Button
           variant="outline"

--- a/client/src/components/app/MiscDetailsContainer/Logs/Xtrem.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/Xtrem.tsx
@@ -20,6 +20,7 @@ type XtermProp = {
   onReady?: () => void;
   onScrollToTop?: () => void;
   isLoadingHistory?: boolean;
+  isAtBottomRef?: MutableRefObject<boolean>;
 };
 
 const DARK_THEME = {
@@ -72,7 +73,7 @@ const LIGHT_THEME = {
   brightWhite: '#1e1e1e',
 };
 
-const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, onReady, onScrollToTop, isLoadingHistory }: XtermProp) => {
+const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, onReady, onScrollToTop, isLoadingHistory, isAtBottomRef }: XtermProp) => {
   const dispatch = useAppDispatch();
   const terminalRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -150,11 +151,13 @@ const XtermTerminal = ({ containerNameProp, xterm, searchAddonRef, updateLogs, o
     const viewport = terminalRef.current.querySelector('.xterm-viewport') as HTMLElement | null;
     const checkScroll = () => {
       if (!viewport) return;
-      if (viewport.clientHeight + viewport.scrollTop < viewport.scrollHeight - 4) {
-        setShowScrollDown(true);
-      } else {
+      const atBottom = viewport.clientHeight + viewport.scrollTop >= viewport.scrollHeight - 4;
+      if (atBottom) {
         setShowScrollDown(false);
+      } else {
+        setShowScrollDown(true);
       }
+      if (isAtBottomRef) isAtBottomRef.current = atBottom;
       if (viewport.scrollTop <= 0) {
         handleScrollToTopDebounced();
       }

--- a/client/src/components/app/MiscDetailsContainer/Logs/index.css
+++ b/client/src/components/app/MiscDetailsContainer/Logs/index.css
@@ -1,7 +1,0 @@
-.logs {
-  height: calc(100vh - 115px);
-}
-
-.xterm-screen {
-  height: calc(100vh - 135px) !important;
-}

--- a/client/src/components/app/MiscDetailsContainer/Logs/index.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Logs/index.tsx
@@ -1,5 +1,3 @@
-import './index.css';
-
 import { ChevronDownIcon, ChevronUpIcon, Cross2Icon, DownloadIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons';
 import { useEffect, useRef, useState } from "react";
 
@@ -165,7 +163,7 @@ const PodLogs = ({ namespace, name, configName, clusterName }: PodLogsProps) => 
   };
 
   return (
-    <div ref={logsPanelRef} className="logs flex-col md:flex border rounded-lg" tabIndex={-1}>
+    <div ref={logsPanelRef} className="flex flex-col h-full border rounded-lg overflow-hidden" tabIndex={-1}>
       <div className="flex items-center h-10 border-b bg-muted/50">
         <div className="flex items-center flex-1 min-w-0 h-full border-r">
           <MagnifyingGlassIcon className="h-3.5 w-3.5 shrink-0 ml-3 text-muted-foreground" />

--- a/client/src/data/Workloads/Pods/fetchLogHistory.ts
+++ b/client/src/data/Workloads/Pods/fetchLogHistory.ts
@@ -1,0 +1,33 @@
+import { PodSocketResponse } from '@/types';
+import kwFetch from '@/data/kwFetch';
+import { API_VERSION } from '@/constants';
+
+export type LogHistoryResponse = {
+  logs: PodSocketResponse[];
+  hasMore: boolean;
+};
+
+export async function fetchLogHistory(
+  podName: string,
+  params: {
+    namespace: string;
+    config: string;
+    cluster: string;
+    container?: string;
+    allContainers?: boolean;
+    before: string;
+    batchSize?: number;
+  }
+): Promise<LogHistoryResponse> {
+  const qp = new URLSearchParams({
+    namespace: params.namespace,
+    config: params.config,
+    cluster: params.cluster,
+    before: params.before,
+    batchSize: String(params.batchSize ?? 500),
+  });
+  if (params.container) qp.set('container', params.container);
+  if (params.allContainers) qp.set('all-containers', 'true');
+
+  return kwFetch(`${API_VERSION}/pods/${podName}/logs/history?${qp}`);
+}


### PR DESCRIPTION
## Summary
- Fix log viewer height overflowing its parent container by replacing fixed `calc(100vh)` CSS with flexbox-based layout
- Add infinite upward scroll to load older pod logs on demand via new `GET /logs/history` REST endpoint
- Cap in-memory log buffer at 50k lines (only trims when user is following live, preserving scroll context when reading)

## Changes

**Height fix:**
- Remove hardcoded `calc(100vh - Xpx)` from log CSS
- Propagate `flex flex-col flex-1 min-h-0` through the full Tabs → Panel → TabsContent chain

**Log history (backend):**
- New `GET /api/v1/pods/:name/logs/history` endpoint
- Accepts `before` timestamp, returns batch of older logs as JSON
- Escalates `tailLines` automatically until enough older logs are found (cap 50k)
- Supports single and multi-container modes

**Infinite scroll (frontend):**
- Detects scroll-to-top in xterm viewport (debounced 300ms)
- Fetches 500-line batches from history endpoint
- Prepends to buffer and re-renders with scroll position preservation
- Queues incoming SSE logs during re-render to avoid data loss
- Conditional buffer trimming: only when user is at bottom (live mode)

## Test plan
- [ ] Open pod logs → window should fit within the visible area, no page overflow
- [ ] Resize browser → terminal auto-adjusts via FitAddon
- [ ] Scroll to top → loading indicator appears, older logs load above
- [ ] Repeat until beginning of logs → loading stops
- [ ] Verify real-time logs keep arriving while scrolled up
- [ ] Switch containers → history state resets
- [ ] Test with all-containers mode
- [ ] Verify other tabs (Overview, YAML, Events) still scroll correctly