### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/backend/handlers/mcp/proxy.go
+++ b/backend/handlers/mcp/proxy.go
@@ -163,7 +163,7 @@ func setProviderAuthHeader(req *http.Request, provider, apiKey string) {
 	default:
 		// Standard Bearer token auth used by: openai, xai, groq, deepinfra,
 		// mistral, togetherai, cohere, fireworks, deepseek, cerebras,
-		// openrouter, ollama, lmstudio, and others.
+		// openrouter, requesty, ollama, lmstudio, and others.
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", apiKey))
 	}
 }

--- a/client/src/components/app/kwAI/Chat/index.tsx
+++ b/client/src/components/app/kwAI/Chat/index.tsx
@@ -162,6 +162,11 @@ const ChatWindow = ({ currentChatKey, cluster, config, isDetailsPage, kwAIStored
         return createOpenRouter({
           apiKey: providerData.apiKey, baseURL: providerData.url, headers: commonHeaders, ...fetchOption
         });
+      case "requesty":
+        // Requesty is an OpenAI-compatible router (base https://router.requesty.ai/v1, Bearer auth).
+        return createOpenAI({
+          apiKey: providerData.apiKey, baseURL: providerData.url, headers: commonHeaders, ...fetchOption
+        });
       default:
         return '';
     }

--- a/client/src/components/app/kwAI/Configuration/icons.tsx
+++ b/client/src/components/app/kwAI/Configuration/icons.tsx
@@ -101,6 +101,14 @@ const OpenRouterIcon: ComponentType<IconProps> = (props) => (
   </svg>
 );
 
+// Neutral placeholder glyph for Requesty (generic router/gateway nodes).
+// Not the official Requesty brand mark — swap in the real logo when available.
+const RequestyIcon: ComponentType<IconProps> = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" fillRule="evenodd" {...props}>
+    <path d="M5 3a2 2 0 100 4 2 2 0 000-4zm0 14a2 2 0 100 4 2 2 0 000-4zm14-7a2 2 0 100 4 2 2 0 000-4zM6.83 5.5h6.67a4 4 0 014 4V11h-1.5V9.5a2.5 2.5 0 00-2.5-2.5H6.83v-1.5zm10.67 8v1.5a2.5 2.5 0 01-2.5 2.5H6.83V16h8.17a1 1 0 001-1v-1.5h1.5z" />
+  </svg>
+);
+
 const PROVIDER_ICONS: Record<string, ComponentType<IconProps>> = {
   xai: XaiIcon,
   openai: OpenAIIcon,
@@ -117,6 +125,7 @@ const PROVIDER_ICONS: Record<string, ComponentType<IconProps>> = {
   ollama: OllamaIcon,
   lmstudio: LMStudioIcon,
   openrouter: OpenRouterIcon,
+  requesty: RequestyIcon,
 };
 
 export { PROVIDER_ICONS };

--- a/client/src/constants/kwAi.ts
+++ b/client/src/constants/kwAi.ts
@@ -117,6 +117,13 @@ const KW_AI_PROVIDERS = [
     providerDefaultUrl: "https://openrouter.ai/api/v1",
     urlHint: "OpenRouter gateway — routes to multiple providers. Default: https://openrouter.ai/api/v1",
     icon: PROVIDER_ICONS.openrouter
+  },
+  {
+    value: "requesty",
+    label: "Requesty",
+    providerDefaultUrl: "https://router.requesty.ai/v1",
+    urlHint: "Requesty router — OpenAI-compatible gateway to multiple providers. Default: https://router.requesty.ai/v1",
+    icon: PROVIDER_ICONS.requesty
   }
 ];
 


### PR DESCRIPTION
Adds Requesty (https://requesty.ai) as an AI provider option, mirroring the existing OpenRouter entry.

- `client/src/constants/kwAi.ts`: new `requesty` entry in `KW_AI_PROVIDERS` (`providerDefaultUrl: "https://router.requesty.ai/v1"`).
- `client/src/components/app/kwAI/Configuration/icons.tsx`: registered a Requesty icon in `PROVIDER_ICONS`. Note: this is a **neutral placeholder** glyph (a generic router/gateway mark, not the official Requesty logo and not a relabeled OpenRouter logo), happy to swap in the real brand asset.
- `client/src/components/app/kwAI/Chat/index.tsx`: `case "requesty"` in the provider factory, routed through the existing `createOpenAI` (Requesty is OpenAI-compatible).

The Go backend uses a generic `Authorization: Bearer` path with no provider allowlist, so no backend change is required (comment updated for accuracy). API keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
