### PR TITLE
fix(mcp): raise bufio.Scanner buffer to avoid 'token too long' on large SSE payloads

### DIFF
--- a/backend/handlers/mcp/helpers/helpers.go
+++ b/backend/handlers/mcp/helpers/helpers.go
@@ -33,6 +33,7 @@ func ReadFirstSSEMessage(url string) (string, error) {
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 8*1024), 10*1024*1024)
 	var data strings.Builder
 
 	for scanner.Scan() {

--- a/backend/handlers/mcp/tools/logs.go
+++ b/backend/handlers/mcp/tools/logs.go
@@ -100,6 +100,7 @@ func ReadLogsStream(sseURL string) ([]LogEntry, error) {
 	var collected []LogEntry
 
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 8*1024), 10*1024*1024)
 	var currentData strings.Builder
 
 	for scanner.Scan() {


### PR DESCRIPTION
## Summary

This PR fixes `error reading SSE stream: bufio.Scanner: token too long` errors that occur whenever an SSE `data:` line exceeds Go's default `bufio.MaxScanTokenSize` (64 KiB). This happens in any real-world cluster with a non-trivial number of pods/nodes, making the kubewall MCP server effectively unusable for `*List` and `*YamlDetails` tool calls.

Fixes #159 — MCP tool fails with 'bufio.Scanner: token too long' on large responses (e.g. pod list)

## What changed

**`backend/handlers/mcp/helpers/helpers.go`**
- Problem: `bufio.NewScanner` in `ReadFirstSSEMessage` used the default 64 KiB max token size. A single SSE `data:` line containing a pod list or YAML payload easily exceeds this, causing `bufio.ErrTooLong`.
- Change: Added `scanner.Buffer(make([]byte, 0, 8*1024), 10*1024*1024)` immediately after scanner construction. 8 KiB initial allocation keeps the common-case memory cost low; 10 MiB cap covers realistic large list/YAML payloads without an unbounded-memory footgun.

**`backend/handlers/mcp/tools/logs.go`**
- Problem: `ReadLogsStream` uses the same default-buffer `bufio.NewScanner` pattern. A single long log line would trigger the same `bufio.ErrTooLong` failure.
- Change: Same one-liner `scanner.Buffer(make([]byte, 0, 8*1024), 10*1024*1024)` applied immediately after scanner construction.

## Acceptance criteria

- [ ] MCP `podsList` tool call succeeds on a cluster with 1,700+ pods without `token too long` error
- [ ] MCP `*YamlDetails` tool call succeeds for resources with large YAML payloads
- [ ] `podsLogs` MCP tool call succeeds for pods with long individual log lines
- [ ] Existing behavior for small payloads is preserved (buffer auto-grows only as needed)

## How to test

1. Deploy kubewall against a cluster with 100+ pods
2. Ask an LLM agent (via kubewall MCP server): _"give me list of top 10 memory consumption pods"_
3. Expected: tool returns results instead of `error reading SSE stream: bufio.Scanner: token too long`
4. Edge case: test with a pod that has a single very long log line (>64 KiB)
5. Edge case: test with a small cluster — behavior should be identical to before

## Notes

- No schema changes
- No new dependencies added
- No server/API changes
- No breaking changes to existing consumers — `scanner.Buffer` is purely additive; it only enlarges the limit, preserving all existing behaviour for payloads under 64 KiB
- The 10 MiB cap matches the pattern used by other LLM-gateway projects for the same reason (e.g. Bifrost's SSE utils)
- No CONTRIBUTING.md found in the repository; used standard Conventional Commits format for commit message and PR title