### PR TITLE
feat: UI improvements across details pages, table toolbar and sidebar

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "@ai-sdk/xai": "^2.0.4",
     "@monaco-editor/react": "^4.6.0",
     "@openrouter/ai-sdk-provider": "^1.1.2",
+    "@peculiar/x509": "^1.14.3",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.1.1",

--- a/client/src/components/app/Common/CodeBlock/colorizer.ts
+++ b/client/src/components/app/Common/CodeBlock/colorizer.ts
@@ -1,0 +1,151 @@
+import type * as Monaco from 'monaco-editor';
+
+type MonacoApi = typeof Monaco;
+
+// Monaco is a multi-MB dependency that the YAML editor already lazy-loads.
+// Importing it dynamically here keeps ConfigMap data blocks out of the main
+// bundle and shares that same async chunk when both are on screen.
+let monacoApi: MonacoApi | null = null;
+let pending: Promise<MonacoApi> | null = null;
+
+const JSON_TOKENIZER_PROBE = '{"a":1}';
+const TOKENIZER_POLL_INTERVAL_MS = 25;
+const TOKENIZER_POLL_ATTEMPTS = 40;
+
+const delay = (ms: number) => new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});
+
+const hasTokenizer = (monaco: MonacoApi, languageId: string, probe: string) =>
+  monaco.editor.tokenize(probe, languageId)[0]?.some(({ type }) => type !== '') ?? false;
+
+/**
+ * Unlike the Monarch grammars, monaco's JSON tokenizer is only installed once
+ * the language is first requested - which happens when a model of that language
+ * is created. Without this warm-up the first colorize(..., 'json') silently
+ * falls back to unhighlighted output, since the tokenizer lands a tick later.
+ */
+const warmUpJson = async (monaco: MonacoApi) => {
+  monaco.editor.createModel('', 'json').dispose();
+  for (let attempt = 0; attempt < TOKENIZER_POLL_ATTEMPTS; attempt++) {
+    if (hasTokenizer(monaco, 'json', JSON_TOKENIZER_PROBE)) {
+      return;
+    }
+    await delay(TOKENIZER_POLL_INTERVAL_MS);
+  }
+};
+
+const loadMonaco = (): Promise<MonacoApi> => {
+  if (!pending) {
+    pending = import('monaco-editor').then(async (monaco) => {
+      await warmUpJson(monaco);
+      monacoApi = monaco;
+      return monaco;
+    });
+  }
+  return pending;
+};
+
+const EXTENSION_LANGUAGES: Record<string, string> = {
+  bash: 'shell',
+  cfg: 'ini',
+  cnf: 'ini',
+  conf: 'ini',
+  env: 'ini',
+  htm: 'html',
+  html: 'html',
+  ini: 'ini',
+  js: 'javascript',
+  json: 'json',
+  lua: 'lua',
+  md: 'markdown',
+  properties: 'ini',
+  py: 'python',
+  sh: 'shell',
+  sql: 'sql',
+  toml: 'ini',
+  ts: 'typescript',
+  xml: 'xml',
+  yaml: 'yaml',
+  yml: 'yaml',
+  zsh: 'shell'
+};
+
+const isJson = (value: string) => {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * ConfigMap keys are filenames often enough that the extension is the most
+ * reliable signal; keys like "setup" or "teardown" carry none, so the content
+ * is sniffed instead. Returns null when nothing matches - better to render a
+ * value plain than to colour it as the wrong language.
+ */
+const detectLanguage = (value: string, fileName?: string): string | null => {
+  const name = fileName?.toLowerCase() ?? '';
+  const extension = name.includes('.') ? name.split('.').pop() : undefined;
+
+  if (extension && EXTENSION_LANGUAGES[extension]) {
+    return EXTENSION_LANGUAGES[extension];
+  }
+  if (name === 'dockerfile' || name.startsWith('dockerfile.')) {
+    return 'dockerfile';
+  }
+
+  const trimmed = value.trim();
+  if (/^#!.*\b(ba|z|k|da)?sh\b/.test(trimmed)) {
+    return 'shell';
+  }
+  if ((trimmed.startsWith('{') || trimmed.startsWith('[')) && isJson(trimmed)) {
+    return 'json';
+  }
+  if (trimmed.startsWith('<')) {
+    return 'xml';
+  }
+  if (/^---\s*$/m.test(trimmed) || /^\s*[\w.\-/]+:(\s|$)/m.test(trimmed)) {
+    return 'yaml';
+  }
+  if (/^\s*\[[^\]\n]+\]\s*$/m.test(trimmed) || /^\s*[\w.-]+\s*=/m.test(trimmed)) {
+    return 'ini';
+  }
+  return null;
+};
+
+/**
+ * Colourises `value` with monaco's tokenizer and returns one HTML string per
+ * line, or null when the language is unknown - callers then render raw text.
+ * Only the tokenizer is used here, not an editor instance, so a ConfigMap with
+ * many keys stays cheap.
+ */
+const colorizeLines = async (value: string, theme: string, fileName?: string): Promise<string[] | null> => {
+  const language = detectLanguage(value, fileName);
+  if (!language) {
+    return null;
+  }
+
+  const monaco = monacoApi ?? await loadMonaco();
+  // The generated `.mtkN` colour rules are global and belong to whichever theme
+  // was last set, so the app theme has to be applied before markup is produced.
+  monaco.editor.setTheme(theme);
+  const html = await monaco.editor.colorize(value, language, { tabSize: 2 });
+
+  // colorize() joins lines with <br/> and appends a trailing one. Its per-line
+  // markup is self-contained and escapes the source text, so splitting here is
+  // safe and each line renders as valid HTML on its own.
+  const lines = html.split('<br/>');
+  if (lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+  return lines;
+};
+
+export {
+  colorizeLines,
+  detectLanguage,
+  loadMonaco
+};

--- a/client/src/components/app/Common/CodeBlock/index.tsx
+++ b/client/src/components/app/Common/CodeBlock/index.tsx
@@ -1,0 +1,77 @@
+import { memo, useEffect, useMemo, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { colorizeLines } from './colorizer';
+import { useTheme } from "@/components/app/ThemeProvider";
+
+type CodeBlockProps = {
+  value: string;
+  /** ConfigMap/Secret key - used to guess the language from its extension. */
+  fileName?: string;
+  className?: string;
+};
+
+const CodeBlock = memo(function ({ value, fileName, className }: CodeBlockProps) {
+  const { monacoTheme } = useTheme();
+  const [colorized, setColorized] = useState<string[] | null>(null);
+
+  // A single trailing newline is a file convention, not a real last line.
+  const lines = useMemo(() => value.replace(/\n$/, '').split('\n'), [value]);
+
+  useEffect(() => {
+    let mounted = true;
+    // Re-runs on theme changes too: monaco's `.mtkN` classes are reused across
+    // themes with different colours behind them, so the markup has to be
+    // regenerated rather than just restyled.
+    colorizeLines(lines.join('\n'), monacoTheme, fileName)
+      .then((result) => mounted && setColorized(result))
+      // Colourising is cosmetic - if monaco fails to load the plain text stays.
+      .catch(() => undefined);
+    return () => {
+      mounted = false;
+    };
+  }, [lines, fileName, monacoTheme]);
+
+  // Guards the render while a newly changed value is still being colourised,
+  // so line numbers can never drift from the content beside them.
+  const colorizedLines = colorized?.length === lines.length ? colorized : null;
+  const showLineNumbers = lines.length > 1;
+  // Keep the gutter wide enough for the largest line number, padding included.
+  const gutterWidth = `calc(${String(lines.length).length}ch + 1.25rem)`;
+  const contentClassName = cn("whitespace-pre-wrap break-all pr-2.5", !showLineNumbers && "pl-2.5");
+
+  return (
+    <div
+      className={cn(
+        "inline-block min-w-0 max-w-full rounded-md bg-secondary py-0.5 font-mono text-[13px] text-secondary-foreground",
+        className
+      )}
+    >
+      {
+        lines.map((line, index) => (
+          <div key={index} className="flex flex-row leading-5 min-h-[1.25rem]">
+            {
+              showLineNumbers &&
+              <span
+                className="shrink-0 select-none px-2.5 text-right tabular-nums text-muted-foreground"
+                style={{ width: gutterWidth }}
+              >
+                {index + 1}
+              </span>
+            }
+            {
+              colorizedLines
+                // monaco escapes the source text, so its markup is safe to inject.
+                ? <span className={contentClassName} dangerouslySetInnerHTML={{ __html: colorizedLines[index] }} />
+                : <span className={contentClassName}>{line}</span>
+            }
+          </div>
+        ))
+      }
+    </div>
+  );
+});
+
+export {
+  CodeBlock
+};

--- a/client/src/components/app/Common/Hooks/Table/index.tsx
+++ b/client/src/components/app/Common/Hooks/Table/index.tsx
@@ -17,6 +17,7 @@ type CreateTableProps<T, C extends HeaderList> = {
   loading: boolean;
   headersList: C[];
   instanceType: string;
+  kind?: string;
   count: number;
   data: T[];
   endpoint: string;
@@ -33,6 +34,7 @@ const CreateTable = <T extends ClusterDetails, C extends HeaderList>({
   headersList,
   count,
   instanceType,
+  kind,
   data,
   endpoint,
   queryParmObject,
@@ -78,6 +80,7 @@ const CreateTable = <T extends ClusterDetails, C extends HeaderList>({
           showNamespaceFilter={showNamespaceFilter}
           tableWidthCss={cn('list-table-max-height', 'h-full')}
           instanceType={instanceType}
+          kind={kind}
           loading={loading}
           showChat={showChat}
           setShowChat={setShowChat}

--- a/client/src/components/app/Common/List/index.tsx
+++ b/client/src/components/app/Common/List/index.tsx
@@ -292,6 +292,7 @@ export function KwList() {
         data={tableData.data as ArrayElement<typeof tableData.data>[]}
         queryParmObject={tableData.queryParams}
         instanceType={tableData.instaceType}
+        kind={kind}
         endpoint={tableData.instaceType}
         dispatchMethod={tableData.dispatchMethod}
         showNamespaceFilter={tableData.showNamespaceFilter}

--- a/client/src/components/app/Details/Card/FixedCard/index.tsx
+++ b/client/src/components/app/Details/Card/FixedCard/index.tsx
@@ -1,6 +1,9 @@
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 
 import { CopyToClipboard } from "@/components/app/Common/CopyToClipboard";
+import { TooltipWrapper } from "@/components/app/Common/TooltipWrapper";
+import { getDisplayTime } from "@/utils";
+import { useNow } from "@/hooks/use-now";
 
 type CardContainerProps = {
   items: {
@@ -9,6 +12,20 @@ type CardContainerProps = {
   }[],
   title?: string;
 };
+
+const AGE_LABEL = 'Age';
+
+function AgeValue({ timestamp }: { timestamp: string }) {
+  const now = useNow();
+
+  return (
+    <TooltipWrapper
+      side="bottom"
+      tooltipString={getDisplayTime(now - new Date(timestamp).getTime())}
+      tooltipContent={timestamp}
+    />
+  );
+}
 
 export function FixedCard({ items, title }: CardContainerProps) {
   return (
@@ -21,13 +38,17 @@ export function FixedCard({ items, title }: CardContainerProps) {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
             {
               items.map(({ label, value }) => {
+                const timestamp = label === AGE_LABEL && typeof value === 'string' && !Number.isNaN(Date.parse(value))
+                  ? value
+                  : null;
+
                 return (
                   <div key={label} className="group/item -mx-2 px-3 transition-all">
                     <div className="flex flex-row">
                       <div className="text-sm font-medium text-muted-foreground basis-1/3">{label}</div>
                       {/* <div className="text-sm font-normal break-all basis-2/3">{value}</div> */}
                       <div className="text-sm font-normal basis-2/3 flex items-center justify-between">
-                        <div className="break-all">{value}</div>
+                        <div className="break-all">{timestamp ? <AgeValue timestamp={timestamp} /> : value}</div>
                         <div className="group/edit invisible group-hover/item:visible">
                           <CopyToClipboard val={value}/>
                           {/* <CopyIcon

--- a/client/src/components/app/MiscDetailsContainer/ClusterRoleBindingDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/ClusterRoleBindingDetailsContainer.tsx
@@ -30,7 +30,7 @@ const ClusterRoleBindingDetailsContainer = memo(function () {
                           {
                             Object.keys(item).map((key: string) => {
                               return (
-                                <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                   <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                   <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                     <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/ClusterRoleDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/ClusterRoleDetailsContainer.tsx
@@ -35,7 +35,7 @@ const ClusterRoleDetailsContainer = memo(function () {
                               {
                                 Object.keys(item).map((key: string) => {
                                   return (
-                                    <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                    <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                       <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                       <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                         <div className="break-all basis-[97%] ">
@@ -85,7 +85,7 @@ const ClusterRoleDetailsContainer = memo(function () {
                                   {
                                     Object.keys(item.matchLabels).map((key: string) => {
                                       return (
-                                        <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                        <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                             <div className="break-all basis-[97%] ">
@@ -127,7 +127,7 @@ const ClusterRoleDetailsContainer = memo(function () {
                                       return (expressionObject ?
                                         Object.keys(expressionObject).map((key: string) => {
                                           return (
-                                            <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                            <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                                 <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/ConfigMapDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/ConfigMapDetailsContainer.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-import { Badge } from "@/components/ui/badge";
+import { CodeBlock } from "../Common/CodeBlock";
 import { CopyToClipboard } from "../Common/CopyToClipboard";
 import { memo } from "react";
 import { useAppSelector } from "@/redux/hooks";
@@ -26,17 +26,16 @@ const ConfigMapDetailsContainer = memo(function () {
               <CardContent className="boder p-0 ">
                 {
                   data && Object.keys(data).map((key: string) => {
+                    // Multi-line values render as a tall code block, where the key
+                    // belongs beside the first line rather than the middle.
+                    const singleLine = !(data[key] || '').replace(/\n$/, '').includes('\n');
+
                     return (
-                      <div className="py-1.5 border-b border-dashed flex flex-row">
+                      <div key={key} className={`py-1.5 border-b last:border-b-0 border-dashed flex flex-row ${singleLine ? 'items-center' : ''}`}>
                         <div className="pl-4 text-sm basis-1/4">{key}</div>
                         <div className="flex flex-row text-sm font-normal basis-3/4 group/item">
                           <div className="break-all basis-[97%] ">
-                            <Badge variant="secondary" className="text-sm font-normal">
-
-                              <span className="whitespace-pre-wrap">
-                                {data[key]}
-                              </span>
-                            </Badge>
+                            <CodeBlock value={data[key] || ''} fileName={key} />
                           </div>
                           <div className="basis-[3%] group/edit invisible group-hover/item:visible flex items-center">
                             <CopyToClipboard

--- a/client/src/components/app/MiscDetailsContainer/CustomResourceDetailsConainter.tsx
+++ b/client/src/components/app/MiscDetailsContainer/CustomResourceDetailsConainter.tsx
@@ -23,7 +23,7 @@ const CustomResourceDetailsContainer = memo(function () {
             {
               Object.keys(spec).map((key: string) => {
                 return (
-                  <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                  <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                     <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                     <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                       <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/EndpointDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/EndpointDetailsContainer.tsx
@@ -48,7 +48,7 @@ const EndpointDetailsContainer = memo(function () {
                                             {
                                               subkey && Object.keys(subkey).map((sskey: keyof typeof subkey) => {
                                                 return (
-                                                  <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                                  <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                                     <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{sskey}</div>
                                                     <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                                       <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/LimitRangeDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/LimitRangeDetailsContainer.tsx
@@ -39,7 +39,7 @@ const LimitRangeDetailsContainer = memo(function () {
                         </CardTitle>
                       </CardHeader>
                       <CardContent className="boder p-0">
-                        <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                        <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Max</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -52,7 +52,7 @@ const LimitRangeDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Min</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -65,7 +65,7 @@ const LimitRangeDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Default</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -78,7 +78,7 @@ const LimitRangeDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Default Request</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -91,7 +91,7 @@ const LimitRangeDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Max Limit Request Ratio</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/NamespaceDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/NamespaceDetailsContainer.tsx
@@ -37,7 +37,7 @@ const NamespaceDetailsContainer = memo(function () {
                           </CardTitle>
                         </CardHeader>
                         <CardContent className="boder p-0">
-                          <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                          <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Status</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -48,7 +48,7 @@ const NamespaceDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Last Transition Time</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -61,7 +61,7 @@ const NamespaceDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Reason</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -74,7 +74,7 @@ const NamespaceDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Message</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -87,7 +87,7 @@ const NamespaceDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Type</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/NodeDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/NodeDetailsContainer.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 import { CopyToClipboard } from "@/components/app/Common/CopyToClipboard";
+import { NodeImages } from "./Nodes/NodeImages";
 import { NodePodsList } from "./Nodes/NodePodsList";
 import { defaultOrValue } from "@/utils";
 import { memo } from "react";
@@ -21,66 +22,7 @@ const NodeDetailsContainer = memo(function () {
       <div className="mb-2">
         <NodePodsList />
       </div>
-      {
-        images && <Card className="shadow-none rounded-lg">
-          <CardHeader className="p-4 ">
-            <CardTitle className="text-sm font-medium">Images <span className="text-xs">({images?.length})</span></CardTitle>
-          </CardHeader>
-          <CardContent className="px-4">
-            <div className="items-start gap-6 rounded-lg grid">
-              {
-                images?.map((image) => {
-                  return (
-                    <div key={image?.sizeBytes} className="grid items-start">
-                      <Card className="shadow-none rounded-lg border-dashed">
-                        {/* <CardHeader className="p-5">
-                        <CardTitle className="flex items-center justify-between">
-                          <div className="flex flex-1 items-center">
-                            <div className="text-sm font-normal basis-2/3 break-all">{image?.type}</div>
-                          </div>
-                        </CardTitle>
-                      </CardHeader> */}
-                        <CardContent className="boder p-0">
-                          <div className="py-1.5 border-t border-b border-dashed flex flex-row">
-                            <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Size</div>
-                            <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
-                              <div className="break-all basis-[97%] ">
-                                {defaultOrValue((Number(image?.sizeBytes) / 1048576).toFixed(2))} MB
-                              </div>
-                              <div className="basis-[3%] group/edit invisible group-hover/item:visible flex items-center">
-                                <CopyToClipboard val={defaultOrValue((Number(image?.sizeBytes) / 1048576).toFixed(2)) + ' MB'} />
-                              </div>
-                            </div>
-                          </div>
-                          {
-                            image?.names?.map((imageName) => {
-                              return (
-                                <div className="py-1.5 border-b border-dashed flex flex-row">
-                                  <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image Name</div>
-                                  <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
-                                    <div className="break-all basis-[97%] ">
-                                      {
-                                        defaultOrValue(imageName)
-                                      }
-                                    </div>
-                                    <div className="basis-[3%] group/edit invisible group-hover/item:visible flex items-center">
-                                      <CopyToClipboard val={defaultOrValue(imageName)} />
-                                    </div>
-                                  </div>
-                                </div>
-                              );
-                            })
-                          }
-                        </CardContent>
-                      </Card>
-                    </div>
-                  );
-                })
-              }
-            </div>
-          </CardContent>
-        </Card>
-      }
+      <NodeImages images={images} />
       {
         conditions && <Card className="mt-2 shadow-none rounded-lg">
           <CardHeader className="p-4 ">
@@ -102,7 +44,7 @@ const NodeDetailsContainer = memo(function () {
                           </CardTitle>
                         </CardHeader>
                         <CardContent className="boder p-0">
-                          <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                          <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Status</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -113,7 +55,7 @@ const NodeDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Last Heartbeat Time</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -126,7 +68,7 @@ const NodeDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Last Transition Time</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -139,7 +81,7 @@ const NodeDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Reason</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -152,7 +94,7 @@ const NodeDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Message</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/Nodes/NodeImages.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Nodes/NodeImages.tsx
@@ -84,7 +84,7 @@ const NodeImages = memo(function ({ images }: NodeImagesProps) {
         </CardTitle>
       </CardHeader>
       <CardContent className="px-4">
-        <div className="grid items-start gap-1.5">
+        <div className="grid grid-cols-2 items-start gap-2">
           {
             visible.map((image) => (
               <ImageRow key={image.names[0]} image={image} widestBytes={summaries[0].sizeBytes} />

--- a/client/src/components/app/MiscDetailsContainer/Nodes/NodeImages.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Nodes/NodeImages.tsx
@@ -1,0 +1,114 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ImageSummary, NodeImage, formatBytes, summarizeNodeImages } from "@/utils/ImageUtils";
+import { memo, useMemo, useState } from "react";
+
+import { CopyToClipboard } from "@/components/app/Common/CopyToClipboard";
+import { Input } from "@/components/ui/input";
+
+type NodeImagesProps = {
+  images?: (NodeImage | undefined)[] | null;
+};
+
+const COLLAPSED_COUNT = 10;
+const DIGEST_HEAD = 14;
+const DIGEST_TAIL = 6;
+
+const shortenDigest = (digest: string) => digest.length > DIGEST_HEAD + DIGEST_TAIL
+  ? `${digest.slice(0, DIGEST_HEAD)}…${digest.slice(-DIGEST_TAIL)}`
+  : digest;
+
+const ImageRow = ({ image, widestBytes }: { image: ImageSummary, widestBytes: number }) => (
+  <div className="group/item relative overflow-hidden rounded-md border border-dashed">
+    {/* The row doubles as its own bar - relative size reads at a glance without costing height. */}
+    <div
+      className="absolute inset-y-0 left-0 bg-secondary"
+      style={{ width: `${widestBytes ? (image.sizeBytes / widestBytes) * 100 : 0}%` }}
+      aria-hidden
+    />
+    <div className="relative flex flex-row items-center gap-3 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-row flex-wrap items-baseline gap-x-1.5 gap-y-1">
+          <span className="text-sm">
+            <span className="text-muted-foreground">{image.prefix}</span>
+            <span className="font-medium">{image.name}</span>
+          </span>
+          {
+            image.tags.map((tag) => (
+              <span key={tag} className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-xs">{tag}</span>
+            ))
+          }
+        </div>
+        {
+          !!image.digest &&
+          <div className="mt-0.5 font-mono text-xs text-muted-foreground">{shortenDigest(image.digest)}</div>
+        }
+      </div>
+      <span className="shrink-0 text-sm tabular-nums">{formatBytes(image.sizeBytes)}</span>
+      <span className="group/edit invisible shrink-0 group-hover/item:visible">
+        <CopyToClipboard val={image.names.join('\n')} />
+      </span>
+    </div>
+  </div>
+);
+
+const NodeImages = memo(function ({ images }: NodeImagesProps) {
+  const [query, setQuery] = useState('');
+  const [showAll, setShowAll] = useState(false);
+
+  const summaries = useMemo(() => summarizeNodeImages(images ?? []), [images]);
+  const matches = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    return term ? summaries.filter(({ names }) => names.some((name) => name.toLowerCase().includes(term))) : summaries;
+  }, [summaries, query]);
+
+  if (!summaries.length) {
+    return null;
+  }
+
+  const totalBytes = summaries.reduce((total, { sizeBytes }) => total + sizeBytes, 0);
+  const visible = showAll ? matches : matches.slice(0, COLLAPSED_COUNT);
+
+  return (
+    <Card className="shadow-none rounded-lg">
+      <CardHeader className="p-4">
+        <CardTitle className="flex flex-row flex-wrap items-center gap-2 text-sm font-medium">
+          <span>Images <span className="text-xs">({summaries.length})</span></span>
+          <span className="text-xs font-normal text-muted-foreground">{formatBytes(totalBytes)} total</span>
+          <Input
+            type="search"
+            value={query}
+            placeholder="Filter images"
+            onChange={(event) => setQuery(event.target.value)}
+            className="ml-auto h-7 w-48 text-xs font-normal shadow-none"
+          />
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">
+        <div className="grid items-start gap-1.5">
+          {
+            visible.map((image) => (
+              <ImageRow key={image.names[0]} image={image} widestBytes={summaries[0].sizeBytes} />
+            ))
+          }
+          {
+            !matches.length &&
+            <div className="py-2 text-sm text-muted-foreground">No images match “{query}”.</div>
+          }
+          {
+            matches.length > COLLAPSED_COUNT &&
+            <button
+              className="justify-self-start text-xs text-blue-600 hover:underline dark:text-blue-500"
+              onClick={() => setShowAll(!showAll)}
+            >
+              {showAll ? 'view less [-]' : `view all ${matches.length} [+]`}
+            </button>
+          }
+        </div>
+      </CardContent>
+    </Card>
+  );
+});
+
+export {
+  NodeImages
+};

--- a/client/src/components/app/MiscDetailsContainer/PodDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/PodDetailsContainer.tsx
@@ -89,7 +89,7 @@ const PodDetailsContainer = memo(function () {
                             </CardTitle>
                           </CardHeader>
                           <CardContent className="boder p-0">
-                            <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                            <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -100,7 +100,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image ID</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -111,7 +111,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Container ID</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -122,7 +122,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Command</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -133,7 +133,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image Pull Policy</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -144,7 +144,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Restarts</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -155,7 +155,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Restart Reason</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -166,7 +166,7 @@ const PodDetailsContainer = memo(function () {
                                 </div>
                               </div>
                             </div>
-                            <div className="py-1.5  border-b border-dashed flex flex-row">
+                            <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                               <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Last Restart</div>
                               <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                 <div className="break-all basis-[97%] ">
@@ -240,7 +240,7 @@ const PodDetailsContainer = memo(function () {
                           </CardTitle>
                         </CardHeader>
                         <CardContent className="boder p-0">
-                          <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                          <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -251,7 +251,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image ID</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -262,7 +262,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Container ID</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -273,7 +273,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Command</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -284,7 +284,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Image Pull Policy</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -295,7 +295,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Restarts</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -306,7 +306,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Restart Reason</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -317,7 +317,7 @@ const PodDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Last Restart</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/PodDisruptionBudgetDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/PodDisruptionBudgetDetailsContainer.tsx
@@ -36,7 +36,7 @@ const PodDisruptionBudgetDetailsContainer = memo(function () {
                         </CardTitle>
                       </CardHeader>
                       <CardContent className="boder p-0">
-                        <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                        <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Status</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -47,7 +47,7 @@ const PodDisruptionBudgetDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Observed Generation</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -60,7 +60,7 @@ const PodDisruptionBudgetDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Last Transition Time</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -73,7 +73,7 @@ const PodDisruptionBudgetDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Reason</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">
@@ -86,7 +86,7 @@ const PodDisruptionBudgetDetailsContainer = memo(function () {
                             </div>
                           </div>
                         </div>
-                        <div className="py-1.5  border-b border-dashed flex flex-row">
+                        <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                           <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Message</div>
                           <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                             <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/ResourceQuotaDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/ResourceQuotaDetailsContainer.tsx
@@ -41,7 +41,7 @@ const ResourceQuotaDetailsContainer = memo(function () {
                           {
                             Object.keys(item).map((key: string) => {
                               return (
-                                <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                   <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                   <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                     <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/RoleBindingDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/RoleBindingDetailsContainer.tsx
@@ -30,7 +30,7 @@ const RoleBindingDetailsContainer = memo(function () {
                           {
                             Object.keys(item).map((key: string) => {
                               return (
-                                <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                   <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                   <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                     <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/RoleDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/RoleDetailsContainer.tsx
@@ -30,7 +30,7 @@ const RoleDetailsContainer = memo(function () {
                           {
                             Object.keys(item).map((key: string) => {
                               return (
-                                <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                   <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                   <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                     <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/RuntimeClassDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/RuntimeClassDetailsContainer.tsx
@@ -27,7 +27,7 @@ const RuntimeClassDetailsContainer = memo(function () {
                     <div key={schedule?.key} className="grid items-start">
                       <Card className="shadow-none rounded-lg border-dashed">
                         <CardContent className="boder p-0">
-                          <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                          <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Effect</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -38,7 +38,7 @@ const RuntimeClassDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Key</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -51,7 +51,7 @@ const RuntimeClassDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Operator</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -64,7 +64,7 @@ const RuntimeClassDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Toleration Seconds</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">
@@ -77,7 +77,7 @@ const RuntimeClassDetailsContainer = memo(function () {
                               </div>
                             </div>
                           </div>
-                          <div className="py-1.5  border-b border-dashed flex flex-row">
+                          <div className="py-1.5  border-b last:border-b-0 border-dashed flex flex-row">
                             <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">Value</div>
                             <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                               <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/SecretDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/SecretDetailsContainer.tsx
@@ -1,11 +1,229 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DockerCredential, HelmRelease, JwtSummary, parseDockerConfig, parseHelmRelease, parseJwt } from "@/utils/SecretUtils";
 import { EyeIcon, EyeOff } from "lucide-react";
-import { memo, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import type { CertificateSummary } from "@/utils/CertificateUtils";
 import { CopyToClipboard } from "../Common/CopyToClipboard";
+import { getDisplayTime } from "@/utils";
+import { parseCertificates } from "@/utils/CertificateUtils";
 import { useAppSelector } from "@/redux/hooks";
+import { useNow } from "@/hooks/use-now";
+
+type SecretData = {
+  [k: string]: string | null;
+} | null | undefined;
+
+const MASKED = '••••••••';
+const HELM_RELEASE_TYPE = 'helm.sh/release.v1';
+
+const decodeSecretValue = (value: string | null) => {
+  try {
+    return atob(value ?? '');
+  } catch {
+    return '';
+  }
+};
+
+const DetailRow = ({ label, children }: { label: string, children: React.ReactNode }) => (
+  <div className="flex flex-row gap-2">
+    <span className="shrink-0 text-muted-foreground">{label}:</span>
+    <span className="break-all">{children}</span>
+  </div>
+);
+
+const SecretCard = ({ title, children }: { title: string, children: React.ReactNode }) => (
+  <div className="mt-2">
+    <Card className="shadow-none rounded-lg">
+      <CardHeader className="p-4">
+        <CardTitle className="text-sm font-medium shadow-none">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">
+        <div className="grid items-start gap-2">{children}</div>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+const SecretBlock = ({ title, children }: { title: string, children: React.ReactNode }) => (
+  <Card className="shadow-none rounded-lg border-dashed overflow-x-auto">
+    <CardContent className="p-3 font-mono text-[13px] leading-5">
+      <div className="mb-1 font-sans text-sm font-medium">{title}</div>
+      {children}
+    </CardContent>
+  </Card>
+);
+
+const RelativeTime = ({ date, now }: { date: Date, now: number }) => {
+  const past = now >= date.getTime();
+
+  return (
+    <>
+      {date.toUTCString()}
+      <span className="ml-2 text-muted-foreground">
+        {past ? `${getDisplayTime(now - date.getTime())} ago` : `in ${getDisplayTime(date.getTime() - now)}`}
+      </span>
+    </>
+  );
+};
+
+const SecretCertificates = memo(function ({ data }: { data: SecretData }) {
+  const now = useNow();
+  const [certificates, setCertificates] = useState<{ key: string, certificate: CertificateSummary }[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    Promise.all(Object.entries(data ?? {}).map(async ([key, value]) => {
+      const parsed = await parseCertificates(decodeSecretValue(value));
+      return parsed.map((certificate) => ({ key, certificate }));
+    })).then((parsed) => mounted && setCertificates(parsed.flat()));
+
+    return () => {
+      mounted = false;
+    };
+  }, [data]);
+
+  if (!certificates.length) {
+    return null;
+  }
+
+  return (
+    <SecretCard title="Certificates">
+      {
+        certificates.map(({ key, certificate }, index) => {
+          const expired = now > certificate.notAfter.getTime();
+          const notYetValid = now < certificate.notBefore.getTime();
+
+          return (
+            <SecretBlock key={`${key}-${index}`} title={key}>
+              <DetailRow label="Serial Number">{certificate.serialNumber}</DetailRow>
+              <DetailRow label="Signature Algorithm">{certificate.signatureAlgorithm}</DetailRow>
+              <DetailRow label="Issuer">{certificate.issuer}</DetailRow>
+              <DetailRow label="Subject">{certificate.subject}</DetailRow>
+              <DetailRow label="Validity">
+                <span className={expired || notYetValid ? 'text-destructive' : 'text-green-600 dark:text-green-400'}>
+                  {expired ? 'Expired' : notYetValid ? 'Not yet valid' : 'Valid'}
+                </span>
+              </DetailRow>
+              <DetailRow label="Not Before"><RelativeTime date={certificate.notBefore} now={now} /></DetailRow>
+              <DetailRow label="Not After"><RelativeTime date={certificate.notAfter} now={now} /></DetailRow>
+              {
+                !!certificate.subjectAltNames.length &&
+                <DetailRow label="Subject Alternative Name">
+                  <span className="flex flex-col">
+                    {certificate.subjectAltNames.map((name) => <span key={name}>{name}</span>)}
+                  </span>
+                </DetailRow>
+              }
+            </SecretBlock>
+          );
+        })
+      }
+    </SecretCard>
+  );
+});
+
+const SecretRegistryCredentials = memo(function ({ data, revealed }: { data: SecretData, revealed: boolean }) {
+  const credentials = useMemo<DockerCredential[]>(() => Object.entries(data ?? {})
+    .filter(([key]) => key === '.dockerconfigjson' || key === '.dockercfg')
+    .flatMap(([, value]) => parseDockerConfig(decodeSecretValue(value))), [data]);
+
+  if (!credentials.length) {
+    return null;
+  }
+
+  return (
+    <SecretCard title="Registry Credentials">
+      {
+        credentials.map(({ registry, username, password, email }) => (
+          <SecretBlock key={registry} title={registry}>
+            <DetailRow label="Username">{username || '—'}</DetailRow>
+            <DetailRow label="Password">{revealed ? password || '—' : MASKED}</DetailRow>
+            {!!email && <DetailRow label="Email">{email}</DetailRow>}
+          </SecretBlock>
+        ))
+      }
+    </SecretCard>
+  );
+});
+
+const SecretTokens = memo(function ({ data }: { data: SecretData }) {
+  const now = useNow();
+  const tokens = useMemo<{ key: string, token: JwtSummary }[]>(() => Object.entries(data ?? {}).flatMap(([key, value]) => {
+    const token = parseJwt(decodeSecretValue(value));
+    return token ? [{ key, token }] : [];
+  }), [data]);
+
+  if (!tokens.length) {
+    return null;
+  }
+
+  return (
+    <SecretCard title="Tokens">
+      {
+        tokens.map(({ key, token }) => (
+          <SecretBlock key={key} title={key}>
+            <DetailRow label="Algorithm">{token.algorithm}</DetailRow>
+            {!!token.issuer && <DetailRow label="Issuer">{token.issuer}</DetailRow>}
+            {!!token.subject && <DetailRow label="Subject">{token.subject}</DetailRow>}
+            {!!token.audience && <DetailRow label="Audience">{token.audience}</DetailRow>}
+            {!!token.namespace && <DetailRow label="Namespace">{token.namespace}</DetailRow>}
+            {!!token.serviceAccount && <DetailRow label="Service Account">{token.serviceAccount}</DetailRow>}
+            {!!token.pod && <DetailRow label="Pod">{token.pod}</DetailRow>}
+            {token.issuedAt && <DetailRow label="Issued"><RelativeTime date={token.issuedAt} now={now} /></DetailRow>}
+            <DetailRow label="Expires">
+              {
+                token.expiresAt
+                  ? <span className={now > token.expiresAt.getTime() ? 'text-destructive' : ''}>
+                    <RelativeTime date={token.expiresAt} now={now} />
+                  </span>
+                  : 'never'
+              }
+            </DetailRow>
+          </SecretBlock>
+        ))
+      }
+    </SecretCard>
+  );
+});
+
+const SecretHelmRelease = memo(function ({ data, type }: { data: SecretData, type?: string | null }) {
+  const now = useNow();
+  const [release, setRelease] = useState<HelmRelease | null>(null);
+
+  useEffect(() => {
+    if (type !== HELM_RELEASE_TYPE) {
+      setRelease(null);
+      return;
+    }
+    let mounted = true;
+    parseHelmRelease(data?.release ?? '').then((parsed) => mounted && setRelease(parsed));
+
+    return () => {
+      mounted = false;
+    };
+  }, [data, type]);
+
+  if (!release) {
+    return null;
+  }
+
+  return (
+    <SecretCard title="Helm Release">
+      <SecretBlock title={release.name || 'release'}>
+        {!!release.chart && <DetailRow label="Chart">{release.chart}</DetailRow>}
+        {!!release.appVersion && <DetailRow label="App Version">{release.appVersion}</DetailRow>}
+        {!!release.revision && <DetailRow label="Revision">{release.revision}</DetailRow>}
+        {!!release.status && <DetailRow label="Status">{release.status}</DetailRow>}
+        {!!release.namespace && <DetailRow label="Namespace">{release.namespace}</DetailRow>}
+        {release.updated && <DetailRow label="Updated"><RelativeTime date={release.updated} now={now} /></DetailRow>}
+        {!!release.description && <DetailRow label="Description">{release.description}</DetailRow>}
+      </SecretBlock>
+    </SecretCard>
+  );
+});
 
 const SecretDetailsContainer = memo(function () {
   const {
@@ -15,58 +233,64 @@ const SecretDetailsContainer = memo(function () {
   const newData = secretsDetails.data;
 
   const getDecodeOrDefault = (secret: string) => {
-    return secretsDetails.type === 'helm.sh/release.v1' ? secret : atob(secret);
+    return secretsDetails.type === HELM_RELEASE_TYPE ? secret : atob(secret);
   };
 
   return (
-    <div className={`mt-2`}>
-      <Card className="shadow-none rounded-lg">
-        <CardHeader className="p-4 ">
-          <CardTitle className="text-sm font-medium flex items-center shadow-none">
-            Data
-            <Button
-              className="ml-1 h-3.5 w-3.5 shadow-none border-none"
-              variant="outline"
-              size="icon"
-              onClick={() => setToggleSecretDecode(!toggleSecretDecode)}
-            >
-              {toggleSecretDecode ? <EyeIcon className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-            </Button>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="px-4">
-          <div className="items-start gap-6 rounded-lg grid">
-            <Card className="shadow-none rounded-lg border-dashed overflow-x-auto">
-              <CardContent className="boder p-0 ">
-                {
-                  newData && Object.keys(newData).map((key: string) => {
-                    return (
-                      <div className="py-1.5 border-b border-solid flex flex-row">
-                        <div className="pl-4 text-sm  basis-1/4">{key}</div>
-                        <div className="flex flex-row text-sm font-normal basis-3/4 group/item">
-                          <div className="break-all basis-[97%] ">
-                            <Badge variant="secondary" className="text-sm font-normal">
-                              <span className={toggleSecretDecode ? 'whitespace-pre-line' : 'line-clamp-1'}>
-                                {toggleSecretDecode ? getDecodeOrDefault(newData[key] || '') : newData[key]}
-                              </span>
-                            </Badge>
-                          </div>
-                          <div className="basis-[3%] group/edit invisible group-hover/item:visible flex items-center">
-                            <CopyToClipboard
-                              val={toggleSecretDecode ? getDecodeOrDefault(newData[key] || '') : newData[key] || ''}
-                            />
+    <>
+      <div className={`mt-2`}>
+        <Card className="shadow-none rounded-lg">
+          <CardHeader className="p-4 ">
+            <CardTitle className="text-sm font-medium flex items-center shadow-none">
+              Data
+              <Button
+                className="ml-1 h-3.5 w-3.5 shadow-none border-none"
+                variant="outline"
+                size="icon"
+                onClick={() => setToggleSecretDecode(!toggleSecretDecode)}
+              >
+                {toggleSecretDecode ? <EyeIcon className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="px-4">
+            <div className="items-start gap-6 rounded-lg grid">
+              <Card className="shadow-none rounded-lg border-dashed overflow-x-auto">
+                <CardContent className="boder p-0 ">
+                  {
+                    newData && Object.keys(newData).map((key: string) => {
+                      return (
+                        <div className={`py-1.5 border-b last:border-b-0 border-solid flex flex-row ${toggleSecretDecode ? '' : 'items-center'}`}>
+                          <div className="pl-4 text-sm  basis-1/4">{key}</div>
+                          <div className="flex flex-row text-sm font-normal basis-3/4 group/item">
+                            <div className="break-all basis-[97%] ">
+                              <Badge variant="secondary" className="text-sm font-normal">
+                                <span className={toggleSecretDecode ? 'whitespace-pre-line' : 'line-clamp-1'}>
+                                  {toggleSecretDecode ? getDecodeOrDefault(newData[key] || '') : newData[key]}
+                                </span>
+                              </Badge>
+                            </div>
+                            <div className="basis-[3%] group/edit invisible group-hover/item:visible flex items-center">
+                              <CopyToClipboard
+                                val={toggleSecretDecode ? getDecodeOrDefault(newData[key] || '') : newData[key] || ''}
+                              />
+                            </div>
                           </div>
                         </div>
-                      </div>
-                    );
-                  })
-                }
-              </CardContent>
-            </Card>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+                      );
+                    })
+                  }
+                </CardContent>
+              </Card>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      <SecretCertificates data={newData} />
+      <SecretRegistryCredentials data={newData} revealed={toggleSecretDecode} />
+      <SecretTokens data={newData} />
+      <SecretHelmRelease data={newData} type={secretsDetails.type} />
+    </>
   );
 });
 

--- a/client/src/components/app/MiscDetailsContainer/ServiceAccountDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/ServiceAccountDetailsContainer.tsx
@@ -30,7 +30,7 @@ const ServiceAccountDetailsContainer = memo(function () {
                           {
                             Object.keys(item).map((key: string) => {
                               return (
-                                <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                   <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                   <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                     <div className="break-all basis-[97%] ">

--- a/client/src/components/app/MiscDetailsContainer/ServiceDetailsContainer.tsx
+++ b/client/src/components/app/MiscDetailsContainer/ServiceDetailsContainer.tsx
@@ -59,7 +59,7 @@ const ServiceDetailsContainer = memo(function () {
                           {
                             Object.keys(item).map((key: string) => {
                               return (
-                                <div className="py-1.5 border-t border-b border-dashed flex flex-row">
+                                <div className="py-1.5 border-t border-b last:border-b-0 border-dashed flex flex-row">
                                   <div className="pl-4 text-sm font-medium text-muted-foreground basis-1/3">{key}</div>
                                   <div className="flex flex-row text-sm font-normal basis-2/3 group/item">
                                     <div className="break-all basis-[97%] ">

--- a/client/src/components/app/Sidebar/index.tsx
+++ b/client/src/components/app/Sidebar/index.tsx
@@ -191,7 +191,7 @@ const Sidebar = memo(function ({ className }: SidebarProps) {
                           className="group/collapsible"
                         >
                           <SidebarMenuItem>
-                            <DropdownMenu>
+                            <DropdownMenu key={`${route}-${open}`}>
                               <CollapsibleTrigger asChild onClick={(e) => { toggleMenu(route); e.stopPropagation(); }}>
                                 <DropdownMenuTrigger asChild>
                                   <SidebarMenuButton className='group-data-[collapsible=icon]:justify-center' tooltip={route} showTooltipOnExpanded={true}>
@@ -232,6 +232,7 @@ const Sidebar = memo(function ({ className }: SidebarProps) {
                                   className=" min-w-56 rounded-lg"
                                   align="start"
                                   side={isMobile ? "bottom" : "right"}
+                                  onCloseAutoFocus={(event) => event.preventDefault()}
                                 >
                                   <DropdownMenuLabel className="truncate font-medium text-gray-800 dark:text-gray-200">{route}</DropdownMenuLabel>
                                   <DropdownMenuSeparator />
@@ -288,7 +289,7 @@ const Sidebar = memo(function ({ className }: SidebarProps) {
                         className="group/collapsible"
                       >
                         <SidebarMenuItem>
-                          <DropdownMenu>
+                          <DropdownMenu key={`${customResourceGroup}-${open}`}>
                             <CollapsibleTrigger asChild onClick={() => toggleMenu(customResourceGroup)}>
                               <DropdownMenuTrigger asChild>
                                 <SidebarMenuButton className='group-data-[collapsible=icon]:justify-center' tooltip={customResourceGroup} showTooltipOnExpanded={true}>
@@ -334,6 +335,7 @@ const Sidebar = memo(function ({ className }: SidebarProps) {
                                 className=" min-w-56 rounded-lg"
                                 align="start"
                                 side={isMobile ? "bottom" : "right"}
+                                onCloseAutoFocus={(event) => event.preventDefault()}
                               >
                                 <DropdownMenuLabel className="truncate font-medium text-gray-800 dark:text-gray-200">{customResourceGroup}</DropdownMenuLabel>
                                 <DropdownMenuSeparator />

--- a/client/src/components/app/Table/TableFacetedFilter/index.tsx
+++ b/client/src/components/app/Table/TableFacetedFilter/index.tsx
@@ -45,8 +45,8 @@ export function DataTableFacetedFilter<TData, TValue>({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="h-8 shadow-none gap-0">
-          <ListFilterIcon className="mr-2 h-4 w-4" />
+        <Button variant="outline" size="sm" className="h-8 px-3 shadow-none gap-0">
+          <ListFilterIcon className="mr-2 h-3.5 w-3.5" />
           {title}
           {selectedValues?.size > 0 && (
             <>

--- a/client/src/components/app/Table/TableToolbar/index.tsx
+++ b/client/src/components/app/Table/TableToolbar/index.tsx
@@ -3,6 +3,7 @@ import { useAppDispatch, useAppSelector } from "@/redux/hooks";
 
 import { AddResource } from "@/components/app/Common/AddResource";
 import { Button } from "@/components/ui/button";
+import { CUSTOM_RESOURCES_LIST_ENDPOINT } from "@/constants";
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { DataTableFacetedFilter } from "@/components/app/Table/TableFacetedFilter";
 import { DataTableViewOptions } from "@/components/app/Table/TableViewOptions";
@@ -27,7 +28,35 @@ type DataTableToolbarProps<TData> = {
   loading?: boolean;
   showChat: boolean;
   setShowChat: React.Dispatch<React.SetStateAction<boolean>>;
+  instanceType: string;
+  kind?: string;
 }
+
+// The endpoint constants are already the resource's plural name ('pods',
+// 'configmaps'), so the few multi-word ones just need spacing out.
+const SEARCH_LABELS: Record<string, string> = {
+  configmaps: 'config maps',
+  cronjobs: 'cron jobs',
+  customresourcedefinitions: 'custom resource definitions',
+  customresources: 'custom resources',
+  daemonsets: 'daemon sets',
+  horizontalpodautoscalers: 'horizontal pod autoscalers',
+  limitranges: 'limit ranges',
+  persistentvolumeclaims: 'persistent volume claims',
+  persistentvolumes: 'persistent volumes',
+  poddisruptionbudgets: 'pod disruption budgets',
+  portforwards: 'port forwards',
+  priorityclasses: 'priority classes',
+  replicasets: 'replica sets',
+  resourcequotas: 'resource quotas',
+  rolebindings: 'role bindings',
+  runtimeclasses: 'runtime classes',
+  serviceaccounts: 'service accounts',
+  statefulsets: 'stateful sets',
+  storageclasses: 'storage classes',
+  clusterrolebindings: 'cluster role bindings',
+  clusterroles: 'cluster roles'
+};
 
 export function DataTableToolbar<TData>({
   table,
@@ -37,12 +66,17 @@ export function DataTableToolbar<TData>({
   loading = true,
   showChat,
   setShowChat,
+  instanceType,
+  kind,
 }: DataTableToolbarProps<TData>) {
   const {
     namespaces
   } = useAppSelector((state: RootState) => state.namespaces);
   const dispatch = useAppDispatch();
   const isFiltered = table.getState().columnFilters.length > 0;
+  const searchTarget = (instanceType === CUSTOM_RESOURCES_LIST_ENDPOINT && kind)
+    || SEARCH_LABELS[instanceType]
+    || instanceType;
 
   return (
     <div className="flex items-center justify-between px-2 py-2">
@@ -52,7 +86,7 @@ export function DataTableToolbar<TData>({
         <div className="relative w-full basis-7/12">
           <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground pointer-events-none" />
           <DebouncedInput
-            placeholder="Type / to search..."
+            placeholder={`Type / to search ${searchTarget}...`}
             value={globalFilter ?? ''}
             onChange={(value) => {
               setGlobalFilter(String(value));

--- a/client/src/components/app/Table/data-table.tsx
+++ b/client/src/components/app/Table/data-table.tsx
@@ -46,6 +46,7 @@ type DataTableProps<TData, TValue> = {
   tableWidthCss: string;
   showNamespaceFilter: boolean;
   instanceType: string;
+  kind?: string;
   showToolbar?: boolean;
   loading?: boolean;
   isEventTable?: boolean;
@@ -82,6 +83,7 @@ export function DataTable<TData, TValue>({
   tableWidthCss,
   showNamespaceFilter,
   instanceType,
+  kind,
   showToolbar = true,
   loading = false,
   isEventTable = false,
@@ -174,13 +176,13 @@ export function DataTable<TData, TValue>({
     <>
       {
         showToolbar
-        && <DataTableToolbar loading={loading} table={table} globalFilter={globalFilter} setGlobalFilter={setGlobalFilter} showNamespaceFilter={showNamespaceFilter} showChat={showChat} setShowChat={setShowChat} />
+        && <DataTableToolbar loading={loading} table={table} globalFilter={globalFilter} setGlobalFilter={setGlobalFilter} showNamespaceFilter={showNamespaceFilter} showChat={showChat} setShowChat={setShowChat} instanceType={instanceType} kind={kind} />
       }
       {
 
         window.safari !== undefined &&
         <div className='flex bg-red-500 dark:bg-red-900 items-center justify-between text-xs font-light px-2 py-1'>
-          <span className='text-xs text-white'>We detected you are on Safari browser and are using http. For seemless expereince switch over to chrome/firefox. More details <a className='underline' href='https://github.com/kubewall/kubewall/wiki/FAQ#https' target='blank'>here</a></span>
+          <span className='text-xs text-white'>We detected you are on Safari browser and are using http. For seemless expereince switch over to HTTPS or chrome/firefox. More details <a className='underline' href='https://github.com/kubewall/kubewall/wiki/FAQ#https' target='blank'>here</a></span>
         </div>
       }
       <ResizablePanelGroup

--- a/client/src/utils/CertificateUtils.ts
+++ b/client/src/utils/CertificateUtils.ts
@@ -1,0 +1,62 @@
+type CertificateSummary = {
+  serialNumber: string;
+  signatureAlgorithm: string;
+  issuer: string;
+  subject: string;
+  notBefore: Date;
+  notAfter: Date;
+  subjectAltNames: string[];
+};
+
+const CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----[\s\S]*?-----END CERTIFICATE-----/g;
+
+const GENERAL_NAME_LABELS: Record<string, string> = {
+  dns: 'DNSName',
+  ip: 'IPAddress',
+  email: 'Email',
+  url: 'URI',
+  dn: 'DirName'
+};
+
+// @peculiar/x509 brings its whole ASN.1 stack along, so it is fetched only once
+// a secret actually turns out to hold certificates.
+let pending: Promise<typeof import('@peculiar/x509')> | null = null;
+
+const loadX509 = () => (pending ??= import('@peculiar/x509'));
+
+const formatAlgorithm = ({ name, hash }: { name: string, hash?: { name: string } }) =>
+  hash?.name ? `${name} with ${hash.name}` : name;
+
+const parseCertificates = async (pem: string): Promise<CertificateSummary[]> => {
+  const blocks = pem.match(CERTIFICATE_PATTERN);
+  if (!blocks) {
+    return [];
+  }
+
+  const { X509Certificate, SubjectAlternativeNameExtension } = await loadX509();
+
+  return blocks.flatMap((block) => {
+    try {
+      const certificate = new X509Certificate(block);
+      const names = certificate.getExtension(SubjectAlternativeNameExtension)?.names.items ?? [];
+
+      return [{
+        serialNumber: certificate.serialNumber.replace(/..\B/g, '$&:'),
+        signatureAlgorithm: formatAlgorithm(certificate.signatureAlgorithm),
+        issuer: certificate.issuer,
+        subject: certificate.subject,
+        notBefore: certificate.notBefore,
+        notAfter: certificate.notAfter,
+        subjectAltNames: names.map(({ type, value }) => `${GENERAL_NAME_LABELS[type] ?? type}(${value})`)
+      }];
+    } catch {
+      return [];
+    }
+  });
+};
+
+export type { CertificateSummary };
+
+export {
+  parseCertificates
+};

--- a/client/src/utils/ImageUtils.ts
+++ b/client/src/utils/ImageUtils.ts
@@ -1,0 +1,76 @@
+type NodeImage = {
+  names?: (string | null)[] | null;
+  sizeBytes?: number | null;
+} | null;
+
+type ImageSummary = {
+  /** Last path segment - what a human calls the image, e.g. "n8n". */
+  name: string;
+  /** Everything before it, e.g. "docker.n8n.io/n8nio/". */
+  prefix: string;
+  tags: string[];
+  digest: string;
+  sizeBytes: number;
+  names: string[];
+};
+
+const SIZE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+const formatBytes = (bytes: number) => {
+  if (!bytes) {
+    return '0 B';
+  }
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), SIZE_UNITS.length - 1);
+  const value = bytes / 1024 ** exponent;
+
+  return `${value.toFixed(exponent && value < 100 ? 2 : 0)} ${SIZE_UNITS[exponent]}`;
+};
+
+/** Splits `[registry/]repository[:tag][@digest]` into its parts. */
+const parseImageReference = (reference: string) => {
+  const [pathAndTag, digest = ''] = reference.split('@');
+  const lastSlash = pathAndTag.lastIndexOf('/');
+  const lastColon = pathAndTag.lastIndexOf(':');
+  const hasTag = lastColon > lastSlash;
+  const repository = hasTag ? pathAndTag.slice(0, lastColon) : pathAndTag;
+
+  return {
+    repository,
+    tag: hasTag ? pathAndTag.slice(lastColon + 1) : '',
+    digest,
+    name: repository.slice(repository.lastIndexOf('/') + 1),
+    prefix: repository.slice(0, repository.lastIndexOf('/') + 1)
+  };
+};
+
+/**
+ * A node reports the same image once per name it is known by - the digest form
+ * and the tagged form - so they are folded into a single entry, largest first.
+ */
+const summarizeNodeImages = (images: (NodeImage | undefined)[]): ImageSummary[] => images
+  .flatMap((image) => {
+    const names = (image?.names ?? []).filter((name): name is string => !!name);
+    if (!names.length) {
+      return [];
+    }
+    const parsed = names.map(parseImageReference);
+    const tagged = parsed.find(({ tag }) => tag) ?? parsed[0];
+
+    return [{
+      name: tagged.name,
+      prefix: tagged.prefix,
+      tags: [...new Set(parsed.map(({ tag }) => tag).filter(Boolean))],
+      digest: parsed.find(({ digest }) => digest)?.digest ?? '',
+      sizeBytes: image?.sizeBytes ?? 0,
+      names
+    }];
+  })
+  .sort((a, b) => b.sizeBytes - a.sizeBytes);
+
+export type { ImageSummary, NodeImage };
+
+export {
+  formatBytes,
+  parseImageReference,
+  summarizeNodeImages
+};

--- a/client/src/utils/SecretUtils.ts
+++ b/client/src/utils/SecretUtils.ts
@@ -1,0 +1,148 @@
+type DockerCredential = {
+  registry: string;
+  username: string;
+  password: string;
+  email: string;
+};
+
+type JwtSummary = {
+  algorithm: string;
+  issuer: string;
+  subject: string;
+  audience: string;
+  issuedAt: Date | null;
+  expiresAt: Date | null;
+  namespace: string;
+  serviceAccount: string;
+  pod: string;
+};
+
+type HelmRelease = {
+  name: string;
+  namespace: string;
+  revision: string;
+  status: string;
+  chart: string;
+  appVersion: string;
+  updated: Date | null;
+  description: string;
+};
+
+type DockerAuthEntry = {
+  username?: string;
+  password?: string;
+  email?: string;
+  auth?: string;
+};
+
+type JwtPayload = {
+  iss?: string;
+  sub?: string;
+  aud?: string | string[];
+  iat?: number;
+  exp?: number;
+  'kubernetes.io'?: {
+    namespace?: string;
+    pod?: { name?: string };
+    serviceaccount?: { name?: string };
+  };
+  // Legacy service-account tokens carry the same facts as flat claims.
+  'kubernetes.io/serviceaccount/namespace'?: string;
+  'kubernetes.io/serviceaccount/service-account.name'?: string;
+};
+
+type HelmReleasePayload = {
+  name?: string;
+  namespace?: string;
+  version?: number;
+  info?: { status?: string, description?: string, last_deployed?: string };
+  chart?: { metadata?: { name?: string, version?: string, appVersion?: string } };
+};
+
+const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*$/;
+
+/** `.dockercfg` is the legacy shape - the same map without the `auths` wrapper. */
+const parseDockerConfig = (value: string): DockerCredential[] => {
+  try {
+    const config = JSON.parse(value) as { auths?: Record<string, DockerAuthEntry> } & Record<string, DockerAuthEntry>;
+    const auths = config.auths ?? config;
+
+    return Object.entries(auths).map(([registry, entry]) => {
+      const [user, secret] = entry.auth ? atob(entry.auth).split(/:(.*)/s) : [];
+      return {
+        registry,
+        username: entry.username || user || '',
+        password: entry.password || secret || '',
+        email: entry.email || ''
+      };
+    });
+  } catch {
+    return [];
+  }
+};
+
+const decodeJwtSegment = (segment: string) => {
+  const base64 = segment.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(atob(base64.padEnd(base64.length + (4 - base64.length % 4) % 4, '=')));
+};
+
+const parseJwt = (token: string): JwtSummary | null => {
+  const trimmed = token.trim();
+  if (!JWT_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    const [header, payload] = trimmed.split('.');
+    const { alg } = decodeJwtSegment(header) as { alg?: string };
+    const claims = decodeJwtSegment(payload) as JwtPayload;
+    if (!alg) {
+      return null;
+    }
+
+    return {
+      algorithm: alg,
+      issuer: claims.iss || '',
+      subject: claims.sub || '',
+      audience: [claims.aud].flat().filter(Boolean).join(', '),
+      issuedAt: claims.iat ? new Date(claims.iat * 1000) : null,
+      expiresAt: claims.exp ? new Date(claims.exp * 1000) : null,
+      namespace: claims['kubernetes.io']?.namespace || claims['kubernetes.io/serviceaccount/namespace'] || '',
+      serviceAccount: claims['kubernetes.io']?.serviceaccount?.name || claims['kubernetes.io/serviceaccount/service-account.name'] || '',
+      pod: claims['kubernetes.io']?.pod?.name || ''
+    };
+  } catch {
+    return null;
+  }
+};
+
+/** Helm stores the release as base64(gzip(json)), which k8s then base64s again. */
+const parseHelmRelease = async (value: string): Promise<HelmRelease | null> => {
+  try {
+    const gzipped = Uint8Array.from(atob(atob(value)), (char) => char.charCodeAt(0));
+    const stream = new Blob([gzipped]).stream().pipeThrough(new DecompressionStream('gzip'));
+    const release = JSON.parse(await new Response(stream).text()) as HelmReleasePayload;
+    const chart = release.chart?.metadata;
+
+    return {
+      name: release.name || '',
+      namespace: release.namespace || '',
+      revision: release.version ? String(release.version) : '',
+      status: release.info?.status || '',
+      chart: chart?.name ? `${chart.name}-${chart.version ?? ''}` : '',
+      appVersion: chart?.appVersion || '',
+      updated: release.info?.last_deployed ? new Date(release.info.last_deployed) : null,
+      description: release.info?.description || ''
+    };
+  } catch {
+    return null;
+  }
+};
+
+export type { DockerCredential, HelmRelease, JwtSummary };
+
+export {
+  parseDockerConfig,
+  parseHelmRelease,
+  parseJwt
+};

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -708,6 +708,136 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
+"@peculiar/asn1-cms@^2.6.0", "@peculiar/asn1-cms@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz#b48a8389319228f929e9acd8cee8da6c858738de"
+  integrity sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    "@peculiar/asn1-x509-attr" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-csr@^2.6.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz#c9bb5dec2eaff824a705e82a4a58d45e6d2c35d0"
+  integrity sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-ecc@^2.6.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz#d51ab2b07eca98e0cf492d051e98bbd0a071305a"
+  integrity sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pfx@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz#8e189b6455e2bf9e5f921bb150ea86d7e7d1875d"
+  integrity sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.8.0"
+    "@peculiar/asn1-pkcs8" "^2.8.0"
+    "@peculiar/asn1-rsa" "^2.8.0"
+    "@peculiar/asn1-schema" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs8@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz#a46cf8857b9b063896afa41d2b8b2aa6a07a70a2"
+  integrity sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs9@^2.6.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz#6d62697af0bbd4f30fdf0d23b4018f3f09620de3"
+  integrity sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.8.0"
+    "@peculiar/asn1-pfx" "^2.8.0"
+    "@peculiar/asn1-pkcs8" "^2.8.0"
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    "@peculiar/asn1-x509-attr" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-rsa@^2.6.0", "@peculiar/asn1-rsa@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz#9d98d0fc42fec50119d2881b8a9925d36daaea73"
+  integrity sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-schema@^2.6.0", "@peculiar/asn1-schema@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz#69699f84259b2161607cabfc34e512a4023dbef9"
+  integrity sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==
+  dependencies:
+    "@peculiar/utils" "^2.0.2"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509-attr@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz#bd168e3f5e8bc23e56b1a97891f9f2fb7f730204"
+  integrity sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/asn1-x509" "^2.8.0"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-x509@^2.6.0", "@peculiar/asn1-x509@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz#9958a9ef35dec8426aabad78ffe8798e318b06e2"
+  integrity sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.8.0"
+    "@peculiar/utils" "^2.0.2"
+    asn1js "^3.0.10"
+    tslib "^2.8.1"
+
+"@peculiar/utils@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/utils/-/utils-2.0.3.tgz#a27ca4c4b73652e110f19a7d16d664f458a5528e"
+  integrity sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==
+  dependencies:
+    tslib "^2.8.1"
+
+"@peculiar/x509@^1.14.3":
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.14.3.tgz#2c44c2b89474346afec38a0c2803ec4fb8ce959e"
+  integrity sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.6.0"
+    "@peculiar/asn1-csr" "^2.6.0"
+    "@peculiar/asn1-ecc" "^2.6.0"
+    "@peculiar/asn1-pkcs9" "^2.6.0"
+    "@peculiar/asn1-rsa" "^2.6.0"
+    "@peculiar/asn1-schema" "^2.6.0"
+    "@peculiar/asn1-x509" "^2.6.0"
+    pvtsutils "^1.3.6"
+    reflect-metadata "^0.2.2"
+    tslib "^2.8.1"
+    tsyringe "^4.10.0"
+
 "@radix-ui/number@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.0.1.tgz#644161a3557f46ed38a042acf4a770e826021674"
@@ -2542,6 +2672,15 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+asn1js@^3.0.10:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.10.tgz#df26c874c8a8b41ca605efea47b2ad07551013dd"
+  integrity sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==
+  dependencies:
+    pvtsutils "^1.3.6"
+    pvutils "^1.1.5"
+    tslib "^2.8.1"
 
 autoprefixer@^10.4.16:
   version "10.4.16"
@@ -4973,6 +5112,18 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+pvtsutils@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.6.tgz#ec46e34db7422b9e4fdc5490578c1883657d6001"
+  integrity sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==
+  dependencies:
+    tslib "^2.8.1"
+
+pvutils@^1.1.5:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.2.0.tgz#4b5487a9cccd52d275b0538775790a3ca982bc22"
+  integrity sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -5141,6 +5292,11 @@ redux@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
   integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
+
+reflect-metadata@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
+  integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
 regexp.prototype.flags@^1.5.1:
   version "1.5.1"
@@ -5615,15 +5771,27 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^2.0.0, tslib@^2.1.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tslib@^2.6.2:
+tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsyringe@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/tsyringe/-/tsyringe-4.10.0.tgz#d0c95815d584464214060285eaaadd94aa03299c"
+  integrity sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==
+  dependencies:
+    tslib "^1.9.3"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION

### ConfigMap data is now use line-numbers

Values render as a code block with line numbers and syntax highlighting, using the Monaco tokenizer we already ship.

<img width="1020" height="608" alt="image" src="https://github.com/user-attachments/assets/53cd7cc4-71f7-459b-9e16-ed66f5e2aa20" />


### Secrets show what's inside a certificate

Any `tls.crt` / `ca.crt` gets a Certificates card with issuer, subject, validity, expiry countdown and SANs.

<img width="956" height="685" alt="image" src="https://github.com/user-attachments/assets/172da25a-8ca2-4438-b441-96f9bd855584" />


### Secrets decode registry credentials, tokens and Helm releases

Docker configs show registry and username (password stays behind the existing eye toggle), JWTs show their claims, and Helm release secrets show chart, revision and status.

<img width="705" height="438" alt="image" src="https://github.com/user-attachments/assets/8ffc5cf8-602e-4195-b283-67a6cde90ef2" />


### Node images redesigned

One row per image with the name parsed out, tag chips, a shortened digest, and a background bar showing relative size — plus total size, a filter box and largest-first ordering.

<img width="981" height="724" alt="image" src="https://github.com/user-attachments/assets/ca66eafc-a64a-4ab5-9f91-58b2288da5a0" />


### Age shows relative time

Details pages now show `47d` instead of a raw timestamp, with the exact time on hover and on copy.

### Search placeholder names the resource

Reads `Type / to search pods...`, and uses the kind on custom resource pages.

<img width="1026" height="143" alt="image" src="https://github.com/user-attachments/assets/2f34f39b-b402-4934-91ba-34e9f45a78bb" />


### Namespace filter button alignment

Icon was oversized next to the label and the padding was lopsided.

### Removed the double border under Data sections

The last row's border sat directly on top of the card's own border.

### Keys line up with their values

Single-line values were taller than the key beside them, so keys sat slightly high.

### Sidebar: no more stray popups after toggling

Opening a nav group while the sidebar was expanded left a hidden dropdown open, which then appeared unprompted once the sidebar collapsed.

This is fixed

<img width="229" height="862" alt="image" src="https://github.com/user-attachments/assets/e2cb34ef-69f7-4d99-9f0c-d08a6e6c618e" />

### Sidebar: tooltip no longer appears after navigating

Picking an item from a collapsed nav dropdown returned focus to the icon, which opened its tooltip on its own.
