### PR TITLE
feat: improve empty serach state and serach fix back fix.

### DIFF
--- a/client/src/components/app/Details/Events/index.tsx
+++ b/client/src/components/app/Details/Events/index.tsx
@@ -59,7 +59,6 @@ export function Events({ instanceType, name, namespace, configName, clusterName,
       tableWidthCss="event-table-max-height rounded-lg"
       instanceType='events'
       showNamespaceFilter={false}
-      isEventTable={true}
       setShowChat={() => { }}
       showChat={false}
     />

--- a/client/src/components/app/Table/TableToolbar/index.tsx
+++ b/client/src/components/app/Table/TableToolbar/index.tsx
@@ -58,6 +58,13 @@ const SEARCH_LABELS: Record<string, string> = {
   clusterroles: 'cluster roles'
 };
 
+// Shared with the empty-state message in DataTable so both refer to the
+// resource the same way.
+export const getSearchTarget = (instanceType: string, kind?: string) =>
+  (instanceType === CUSTOM_RESOURCES_LIST_ENDPOINT && kind)
+  || SEARCH_LABELS[instanceType]
+  || instanceType;
+
 export function DataTableToolbar<TData>({
   table,
   globalFilter,
@@ -74,9 +81,7 @@ export function DataTableToolbar<TData>({
   } = useAppSelector((state: RootState) => state.namespaces);
   const dispatch = useAppDispatch();
   const isFiltered = table.getState().columnFilters.length > 0;
-  const searchTarget = (instanceType === CUSTOM_RESOURCES_LIST_ENDPOINT && kind)
-    || SEARCH_LABELS[instanceType]
-    || instanceType;
+  const searchTarget = getSearchTarget(instanceType, kind);
 
   return (
     <div className="flex items-center justify-between px-2 py-2">

--- a/client/src/components/app/Table/data-table.tsx
+++ b/client/src/components/app/Table/data-table.tsx
@@ -24,12 +24,15 @@ import {
   TableRow
 } from "@/components/ui/table";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useAppDispatch, useAppSelector } from "@/redux/hooks";
 
-import { DataTableToolbar } from "@/components/app/Table/TableToolbar";
+import { Button } from "@/components/ui/button";
+import { DataTableToolbar, getSearchTarget } from "@/components/app/Table/TableToolbar";
 import { Loader } from '@/components/app/Loader';
 import { RootState } from "@/redux/store";
 import { TableDelete } from './TableDelete';
-import { useAppSelector } from "@/redux/hooks";
+import { X } from "lucide-react";
+import { resetListTableFilter } from "@/data/Misc/ListTableFilterSlice";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 // Rows are single-line and fairly uniform; this is just a starting estimate -
@@ -49,7 +52,6 @@ type DataTableProps<TData, TValue> = {
   kind?: string;
   showToolbar?: boolean;
   loading?: boolean;
-  isEventTable?: boolean;
   showChat: boolean;
   setShowChat: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -86,11 +88,11 @@ export function DataTable<TData, TValue>({
   kind,
   showToolbar = true,
   loading = false,
-  isEventTable = false,
   setShowChat,
   showChat
 }: DataTableProps<TData, TValue>) {
 
+  const dispatch = useAppDispatch();
   const {
     searchString
   } = useAppSelector((state: RootState) => state.listTableFilter);
@@ -172,6 +174,11 @@ export function DataTable<TData, TValue>({
     setFullScreen(false);
   };
 
+  const handleClearSearch = () => {
+    setGlobalFilter('');
+    dispatch(resetListTableFilter());
+  };
+
   return (
     <>
       {
@@ -191,7 +198,7 @@ export function DataTable<TData, TValue>({
         {
           !fullScreen &&
           <ResizablePanel id="table" order={1} defaultSize={showChat ? 55 : 100}>
-            <div ref={tableContainerRef} className={`border border-x-0 overflow-auto ${tableWidthCss} `}>
+            <div ref={tableContainerRef} className={`relative border border-x-0 overflow-auto ${tableWidthCss} `}>
               {
                 Object.keys(rowSelection).length > 0 &&
                 <TableDelete selectedRows={table.getSelectedRowModel().rows} toggleAllRowsSelected={table.resetRowSelection} />
@@ -256,18 +263,31 @@ export function DataTable<TData, TValue>({
                         </tr>
                       )}
                     </>
-                  ) : (
-                    <TableRow className={isEventTable ? 'empty-table-events' : 'empty-table'}>
-                      <TableCell
-                        colSpan={columns.length}
-                        className="text-center"
-                      >
-                        No results.
-                      </TableCell>
-                    </TableRow>
-                  )}
+                  ) : null}
                 </TableBody>
               </Table>
+              {!rows.length && (
+                <div className="absolute inset-x-0 top-10 bottom-0 flex items-center justify-center pointer-events-none">
+                  <div className="flex flex-col items-center gap-2 text-center pointer-events-auto">
+                    {globalFilter ? (
+                      <>
+                        <p>No results found for search term &quot;{globalFilter}&quot;</p>
+                        <p className="text-sm text-muted-foreground">Check the spelling, or try a shorter search term.</p>
+                        <Button
+                          variant="secondary"
+                          onClick={handleClearSearch}
+                          className="mt-1 h-8 gap-1.5 px-3"
+                        >
+                          Clear Search
+                          <X className="h-3.5 w-3.5" />
+                        </Button>
+                      </>
+                    ) : (
+                      <p>No {getSearchTarget(instanceType, kind)} found in cluster.</p>
+                    )}
+                  </div>
+                </div>
+              )}
               </TooltipProvider>
             </div>
           </ResizablePanel>

--- a/client/src/data/Misc/ListTableFilterSlice.ts
+++ b/client/src/data/Misc/ListTableFilterSlice.ts
@@ -1,6 +1,33 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { resetAllStates } from '@/redux/hooks';
 
+const SEARCH_STORAGE_KEY = 'kw.listTableSearch';
+
+// The store is torn down by a reload and by anything that remounts the list
+// route, which is why what you typed used to vanish on refresh and on the way
+// back from a details page. sessionStorage keeps it for the life of the tab -
+// long enough to survive both - without leaking an old search into a new one.
+const readSearchString = () => {
+  try {
+    return sessionStorage.getItem(SEARCH_STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+};
+
+const writeSearchString = (searchString: string) => {
+  try {
+    if (searchString) {
+      sessionStorage.setItem(SEARCH_STORAGE_KEY, searchString);
+    } else {
+      sessionStorage.removeItem(SEARCH_STORAGE_KEY);
+    }
+  } catch {
+    // Storage being unavailable (private mode, quota) only costs us the
+    // remembered search, so there is nothing useful to do here.
+  }
+};
+
 type InitialState = {
   searchString: string
 };
@@ -11,17 +38,22 @@ const initialState: InitialState = {
 
 const listTableFilterSlice = createSlice({
   name: 'listTableFilter',
-  initialState,
+  initialState: { ...initialState, searchString: readSearchString() },
   reducers: {
     updateListTableFilter: (state, action) => {
       state.searchString = action.payload;
+      writeSearchString(action.payload);
     },
     resetListTableFilter: () => {
+      writeSearchString('');
       return initialState;
     }
   },
   extraReducers: (builder) => {
-    builder.addCase(resetAllStates, () => initialState);
+    builder.addCase(resetAllStates, () => {
+      writeSearchString('');
+      return initialState;
+    });
   },
 });
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -109,10 +109,6 @@ body {
   overflow: hidden;
 }
 
-.empty-table {
-  height: calc(100vh - 90px - var(--terminal-height, 0px));
-}
-
 @keyframes bgColorChange {
   0% {
     background-color: hsl(var(--muted-foreground)/0.2);


### PR DESCRIPTION
This PR adds
-  the empty search state to table.
- fix: when search something goes into details page, goes back search loose it's state.


**Screenshot of new empty search state**
<img width="845" height="301" alt="image" src="https://github.com/user-attachments/assets/00c75ff0-ba04-4683-b66c-d90674c4e09e" />
