### PR TITLE
feat: Add Pods list to Job, DaemonSet, StatefulSet & ReplicaSet details (Jobs list for CronJob)

### DIFF
--- a/backend/handlers/base/ownerstreams.go
+++ b/backend/handlers/base/ownerstreams.go
@@ -1,0 +1,41 @@
+package base
+
+import "sync"
+
+// OwnerStreams remembers which per-owner streams a publisher last wrote to.
+type OwnerStreams struct {
+	pass sync.Mutex
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+func NewOwnerStreams() *OwnerStreams {
+	return &OwnerStreams{seen: make(map[string]struct{})}
+}
+
+func (o *OwnerStreams) Begin() func() {
+	o.pass.Lock()
+	return o.pass.Unlock
+}
+
+// Diff adopts current as the new baseline and returns the streams that were
+// published to on the previous pass but hold no children in this one.
+func (o *OwnerStreams) Diff(current []string) []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	next := make(map[string]struct{}, len(current))
+	for _, id := range current {
+		next[id] = struct{}{}
+	}
+
+	emptied := make([]string, 0)
+	for id := range o.seen {
+		if _, populated := next[id]; !populated {
+			emptied = append(emptied, id)
+		}
+	}
+	o.seen = next
+
+	return emptied
+}

--- a/backend/handlers/base/ownerstreams_test.go
+++ b/backend/handlers/base/ownerstreams_test.go
@@ -1,0 +1,80 @@
+package base
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOwnerStreamsDiff(t *testing.T) {
+	t.Run("reports nothing on the first pass", func(t *testing.T) {
+		o := NewOwnerStreams()
+
+		assert.Empty(t, o.Diff([]string{"a", "b"}))
+	})
+
+	t.Run("reports the streams that lost their last child", func(t *testing.T) {
+		o := NewOwnerStreams()
+		o.Diff([]string{"a", "b", "c"})
+
+		assert.ElementsMatch(t, []string{"a", "c"}, o.Diff([]string{"b"}))
+	})
+
+	t.Run("reports an emptied stream only once", func(t *testing.T) {
+		o := NewOwnerStreams()
+		o.Diff([]string{"a"})
+
+		assert.Equal(t, []string{"a"}, o.Diff(nil))
+		assert.Empty(t, o.Diff(nil))
+	})
+
+	t.Run("a stream that comes back can empty again", func(t *testing.T) {
+		o := NewOwnerStreams()
+		o.Diff([]string{"a"})
+		o.Diff(nil)
+		o.Diff([]string{"a"})
+
+		assert.Equal(t, []string{"a"}, o.Diff(nil))
+	})
+
+	t.Run("keeps streams that are still populated", func(t *testing.T) {
+		o := NewOwnerStreams()
+		o.Diff([]string{"a", "b"})
+
+		assert.Empty(t, o.Diff([]string{"a", "b"}))
+	})
+}
+
+func TestOwnerStreamsBegin(t *testing.T) {
+	t.Run("serialises concurrent passes", func(t *testing.T) {
+		o := NewOwnerStreams()
+
+		inFlight := 0
+		overlapped := false
+		var guard sync.Mutex
+		var wg sync.WaitGroup
+
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer o.Begin()()
+
+				guard.Lock()
+				inFlight++
+				overlapped = overlapped || inFlight > 1
+				guard.Unlock()
+
+				o.Diff([]string{"a"})
+
+				guard.Lock()
+				inFlight--
+				guard.Unlock()
+			}()
+		}
+		wg.Wait()
+
+		assert.False(t, overlapped)
+	})
+}

--- a/backend/handlers/workloads/cronJobs/cronJobs.go
+++ b/backend/handlers/workloads/cronJobs/cronJobs.go
@@ -9,8 +9,13 @@ import (
 	"github.com/kubewall/kubewall/backend/container"
 	"github.com/kubewall/kubewall/backend/handlers/base"
 	"github.com/kubewall/kubewall/backend/handlers/helpers"
+	"github.com/kubewall/kubewall/backend/handlers/workloads/jobs"
 	"github.com/labstack/echo/v4"
 	batchV1 "k8s.io/api/batch/v1"
+)
+
+const (
+	GetJobs base.RouteType = 12
 )
 
 type CronJobsHandler struct {
@@ -32,6 +37,8 @@ func NewCronJobsRouteHandler(container container.Container, routeType base.Route
 			return handler.BaseHandler.GetYaml(c)
 		case base.Delete:
 			return handler.BaseHandler.Delete(c)
+		case GetJobs:
+			return handler.GetJobs(c)
 		default:
 			return echo.NewHTTPError(http.StatusInternalServerError, "Unknown route type")
 		}
@@ -78,4 +85,21 @@ func transformItems(items []any, b *base.BaseHandler) ([]byte, error) {
 	t := TransformCronJobsList(cronJobList)
 
 	return json.Marshal(t)
+}
+
+// GetJobs streams the jobs a CronJob has spawned to its details view.
+func (h *CronJobsHandler) GetJobs(c echo.Context) error {
+	config := c.QueryParam("config")
+	cluster := c.QueryParam("cluster")
+	namespace := c.QueryParam("namespace")
+	name := c.Param("name")
+
+	streamID := jobs.CronJobJobsStreamID(h.BaseHandler.QueryConfig, h.BaseHandler.QueryCluster, namespace, name)
+	ctx := c.Request().Context()
+	// Register before publishing; see BaseHandler.GetList.
+	h.BaseHandler.Container.SSE().CreateStream(streamID)
+	go jobs.NewJobsHandler(ctx, config, cluster, h.BaseHandler.Container).PublishCronJobJobs(namespace, name)
+	h.BaseHandler.Container.SSE().ServeHTTP(streamID, c.Response(), c.Request())
+
+	return nil
 }

--- a/backend/handlers/workloads/jobs/cronJobJobs.go
+++ b/backend/handlers/workloads/jobs/cronJobJobs.go
@@ -1,0 +1,97 @@
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/r3labs/sse/v2"
+	batchV1 "k8s.io/api/batch/v1"
+)
+
+// CronJobsResource is the route segment a CronJob details view subscribes under,
+// and the resource segment of the stream ID below.
+const CronJobsResource = "cronjobs"
+
+// CronJobJobsStreamID keys the job stream of a single CronJob. As with the
+// per-workload pod streams the namespace is part of the key, so the same CronJob
+// deployed to several namespaces gets a stream per namespace.
+func CronJobJobsStreamID(config, cluster, namespace, name string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s-jobs", config, cluster, CronJobsResource, namespace, name)
+}
+
+// CronJobJobs publishes the job list of every CronJob that owns one, in a single
+// pass over the informer store.
+func (h *JobsHandler) CronJobJobs() {
+	defer h.ownerStreams.Begin()()
+
+	jobsByCronJob := make(map[string][]batchV1.Job)
+	for _, obj := range h.BaseHandler.Informer.GetStore().List() {
+		job, ok := obj.(*batchV1.Job)
+		if !ok {
+			continue
+		}
+		if streamID, owned := h.cronJobJobsStreamID(job); owned {
+			jobsByCronJob[streamID] = append(jobsByCronJob[streamID], *job)
+		}
+	}
+
+	streamIDs := make([]string, 0, len(jobsByCronJob))
+	for streamID := range jobsByCronJob {
+		streamIDs = append(streamIDs, streamID)
+	}
+	sort.Strings(streamIDs)
+
+	for _, streamID := range streamIDs {
+		h.publishJobs(streamID, jobsByCronJob[streamID])
+	}
+
+	for _, streamID := range h.ownerStreams.Diff(streamIDs) {
+		h.BaseHandler.Container.SSE().Publish(streamID, &sse.Event{Data: []byte("[]")})
+	}
+}
+
+// PublishCronJobJobs pushes one CronJob's jobs on demand, for a details view that
+// has just subscribed. It publishes even when the CronJob has spawned none yet,
+// so the view resolves to an empty table rather than to skeleton rows.
+func (h *JobsHandler) PublishCronJobJobs(namespace, name string) {
+	streamID := CronJobJobsStreamID(h.BaseHandler.QueryConfig, h.BaseHandler.QueryCluster, namespace, name)
+
+	owned := make([]batchV1.Job, 0)
+	for _, obj := range h.BaseHandler.Informer.GetStore().List() {
+		job, ok := obj.(*batchV1.Job)
+		if !ok || job.GetNamespace() != namespace {
+			continue
+		}
+		if id, isOwned := h.cronJobJobsStreamID(job); isOwned && id == streamID {
+			owned = append(owned, *job)
+		}
+	}
+
+	h.publishJobs(streamID, owned)
+}
+
+// cronJobJobsStreamID returns the stream a job belongs on. A Job has at most one
+// CronJob owner, so unlike a pod it maps to a single stream or to none.
+func (h *JobsHandler) cronJobJobsStreamID(job *batchV1.Job) (string, bool) {
+	for _, owner := range job.GetOwnerReferences() {
+		if owner.Kind != "CronJob" {
+			continue
+		}
+		return CronJobJobsStreamID(
+			h.BaseHandler.QueryConfig,
+			h.BaseHandler.QueryCluster,
+			job.GetNamespace(),
+			owner.Name,
+		), true
+	}
+	return "", false
+}
+
+func (h *JobsHandler) publishJobs(streamID string, owned []batchV1.Job) {
+	data, err := json.Marshal(TransformJobsList(owned))
+	if err != nil {
+		data = []byte("[]")
+	}
+	h.BaseHandler.Container.SSE().Publish(streamID, &sse.Event{Data: data})
+}

--- a/backend/handlers/workloads/jobs/cronJobJobs_test.go
+++ b/backend/handlers/workloads/jobs/cronJobJobs_test.go
@@ -1,0 +1,66 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/kubewall/kubewall/backend/handlers/base"
+	"github.com/stretchr/testify/assert"
+	batchV1 "k8s.io/api/batch/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testJobsHandler() *JobsHandler {
+	return &JobsHandler{
+		BaseHandler: base.BaseHandler{
+			QueryConfig:  "cfg",
+			QueryCluster: "clu",
+		},
+		ownerStreams: base.NewOwnerStreams(),
+	}
+}
+
+func ownedJob(namespace string, owners ...metaV1.OwnerReference) *batchV1.Job {
+	return &batchV1.Job{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:            "job",
+			Namespace:       namespace,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func TestCronJobJobsStreamID(t *testing.T) {
+	t.Run("namespace separates same-named cronjobs", func(t *testing.T) {
+		staging := CronJobJobsStreamID("cfg", "clu", "staging", "nightly")
+		prod := CronJobJobsStreamID("cfg", "clu", "prod", "nightly")
+
+		assert.NotEqual(t, staging, prod)
+	})
+}
+
+func TestCronJobJobsStreamIDForJob(t *testing.T) {
+	h := testJobsHandler()
+
+	t.Run("maps a job onto its cronjob's stream", func(t *testing.T) {
+		job := ownedJob("default", metaV1.OwnerReference{Kind: "CronJob", Name: "nightly"})
+
+		streamID, owned := h.cronJobJobsStreamID(job)
+
+		assert.True(t, owned)
+		assert.Equal(t, CronJobJobsStreamID("cfg", "clu", "default", "nightly"), streamID)
+	})
+
+	t.Run("skips owner kinds other than CronJob", func(t *testing.T) {
+		job := ownedJob("default", metaV1.OwnerReference{Kind: "Workflow", Name: "pipeline"})
+
+		_, owned := h.cronJobJobsStreamID(job)
+
+		assert.False(t, owned)
+	})
+
+	t.Run("skips a standalone job", func(t *testing.T) {
+		_, owned := h.cronJobJobsStreamID(ownedJob("default"))
+
+		assert.False(t, owned)
+	})
+}

--- a/backend/handlers/workloads/jobs/jobs.go
+++ b/backend/handlers/workloads/jobs/jobs.go
@@ -14,7 +14,8 @@ import (
 )
 
 type JobsHandler struct {
-	BaseHandler base.BaseHandler
+	BaseHandler  base.BaseHandler
+	ownerStreams *base.OwnerStreams
 }
 
 func NewJobsRouteHandler(container container.Container, routeType base.RouteType) echo.HandlerFunc {
@@ -60,9 +61,18 @@ func newJobsHandler(ctx context.Context, config, cluster string, container conta
 			InformerCacheKey: fmt.Sprintf("%s-%s-jobsInformer", config, cluster),
 			TransformFunc:    transformItems,
 		},
+		ownerStreams: base.NewOwnerStreams(),
 	}
 
-	cache := base.ResourceEventHandler[*batchV1.Job](&handler.BaseHandler)
+	additionalEvents := []map[string]func(){
+		{
+			"jobs-cronjobs": func() {
+				go handler.CronJobJobs()
+			},
+		},
+	}
+
+	cache := base.ResourceEventHandler[*batchV1.Job](&handler.BaseHandler, additionalEvents...)
 	handler.BaseHandler.StartInformer(cache)
 	handler.BaseHandler.WaitForSync(ctx)
 	return handler

--- a/backend/handlers/workloads/pods/ownerPods.go
+++ b/backend/handlers/workloads/pods/ownerPods.go
@@ -1,0 +1,156 @@
+package pods
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/kubewall/kubewall/backend/container"
+	"github.com/labstack/echo/v4"
+	"github.com/r3labs/sse/v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
+)
+
+// Route segments of the workloads whose details view carries a pod list. They
+// double as the resource segment of the stream ID, so a view subscribing to
+// api/v1/<resource>/<name>/pods and the publisher below agree on the key.
+const (
+	JobsResource         = "jobs"
+	DaemonSetsResource   = "daemonsets"
+	StatefulSetsResource = "statefulsets"
+	ReplicaSetsResource  = "replicasets"
+)
+
+// podOwnerResources maps the owner kinds that appear directly on a pod's owner
+// references onto the resource their details view is served under.
+//
+// ReplicaSet is here as well as in DeploymentsPods, and the two do not overlap:
+// this keys on the ReplicaSet itself, which is what a ReplicaSet details view
+// asks for, while DeploymentsPods walks one further up to the Deployment.
+var podOwnerResources = map[string]string{
+	"Job":         JobsResource,
+	"DaemonSet":   DaemonSetsResource,
+	"StatefulSet": StatefulSetsResource,
+	"ReplicaSet":  ReplicaSetsResource,
+}
+
+// OwnerPodsStreamID keys the pod stream of a single namespaced workload. Unlike
+// the node and deployment pod streams the namespace is part of the key: workloads
+// sharing a name across namespaces are routine - a CronJob rolled out to several
+// namespaces spawns identically named Jobs in each - and must not share a stream.
+func OwnerPodsStreamID(config, cluster, resource, namespace, name string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s-pods", config, cluster, resource, namespace, name)
+}
+
+// NewOwnerPodsRouteHandler serves api/v1/<resource>/:name/pods for a workload
+// whose pods this package publishes. The route lives here rather than on each
+// workload's own handler because pods is what owns these streams, and because
+// pods already imports replicaset to walk pod -> ReplicaSet -> Deployment, so a
+// ReplicaSet handler could not import it back.
+func NewOwnerPodsRouteHandler(container container.Container, resource string) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		handler := NewPodsHandler(c.Request().Context(), c.QueryParam("config"), c.QueryParam("cluster"), container)
+		return handler.ServeOwnerPods(c, resource)
+	}
+}
+
+// ServeOwnerPods streams one workload's pods to a details view, on the same
+// stream OwnerPods publishes to.
+func (h *PodsHandler) ServeOwnerPods(c echo.Context, resource string) error {
+	namespace := c.QueryParam("namespace")
+	name := c.Param("name")
+
+	streamID := OwnerPodsStreamID(h.BaseHandler.QueryConfig, h.BaseHandler.QueryCluster, resource, namespace, name)
+	// Register before publishing; see BaseHandler.GetList.
+	h.BaseHandler.Container.SSE().CreateStream(streamID)
+	go h.PublishOwnerPods(resource, namespace, name)
+	h.BaseHandler.Container.SSE().ServeHTTP(streamID, c.Response(), c.Request())
+
+	return nil
+}
+
+// OwnerPods publishes the pod list of every Job, DaemonSet, StatefulSet and
+// ReplicaSet that owns one, in a single pass over the informer store.
+func (h *PodsHandler) OwnerPods() {
+	defer h.ownerStreams.Begin()()
+
+	podsByOwner := make(map[string][]v1.Pod)
+	for _, obj := range h.BaseHandler.Informer.GetStore().List() {
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			continue
+		}
+		for _, streamID := range h.ownerPodsStreamIDs(pod) {
+			podsByOwner[streamID] = append(podsByOwner[streamID], *pod)
+		}
+	}
+
+	streamIDs := make([]string, 0, len(podsByOwner))
+	for streamID := range podsByOwner {
+		streamIDs = append(streamIDs, streamID)
+	}
+	sort.Strings(streamIDs)
+
+	if len(streamIDs) > 0 {
+		podsMetricsList := GetPodsMetricsList(&h.BaseHandler)
+		for _, streamID := range streamIDs {
+			h.publishPods(streamID, podsByOwner[streamID], podsMetricsList)
+		}
+	}
+
+	for _, streamID := range h.ownerStreams.Diff(streamIDs) {
+		h.BaseHandler.Container.SSE().Publish(streamID, &sse.Event{Data: []byte("[]")})
+	}
+}
+
+// PublishOwnerPods pushes one workload's pods on demand, for a details view that
+// has just subscribed. It publishes even when the workload owns none - a
+// suspended Job, or one whose pods its TTL already reaped - so the view resolves
+// to an empty table instead of showing skeleton rows until some unrelated pod
+// event happens to trigger a full pass.
+func (h *PodsHandler) PublishOwnerPods(resource, namespace, name string) {
+	streamID := OwnerPodsStreamID(h.BaseHandler.QueryConfig, h.BaseHandler.QueryCluster, resource, namespace, name)
+
+	owned := make([]v1.Pod, 0)
+	for _, obj := range h.BaseHandler.Informer.GetStore().List() {
+		pod, ok := obj.(*v1.Pod)
+		if !ok || pod.GetNamespace() != namespace {
+			continue
+		}
+		if slices.Contains(h.ownerPodsStreamIDs(pod), streamID) {
+			owned = append(owned, *pod)
+		}
+	}
+
+	h.publishPods(streamID, owned, GetPodsMetricsList(&h.BaseHandler))
+}
+
+// ownerPodsStreamIDs returns the streams a pod belongs on - one per tracked
+// controller in its owner references.
+func (h *PodsHandler) ownerPodsStreamIDs(pod *v1.Pod) []string {
+	var streamIDs []string
+	for _, owner := range pod.GetOwnerReferences() {
+		resource, tracked := podOwnerResources[owner.Kind]
+		if !tracked {
+			continue
+		}
+		streamIDs = append(streamIDs, OwnerPodsStreamID(
+			h.BaseHandler.QueryConfig,
+			h.BaseHandler.QueryCluster,
+			resource,
+			pod.GetNamespace(),
+			owner.Name,
+		))
+	}
+	return streamIDs
+}
+
+func (h *PodsHandler) publishPods(streamID string, owned []v1.Pod, podsMetricsList *v1beta1.PodMetricsList) {
+	data, err := json.Marshal(TransformPodList(owned, podsMetricsList))
+	if err != nil {
+		data = []byte("[]")
+	}
+	h.BaseHandler.Container.SSE().Publish(streamID, &sse.Event{Data: data})
+}

--- a/backend/handlers/workloads/pods/ownerPods_test.go
+++ b/backend/handlers/workloads/pods/ownerPods_test.go
@@ -1,0 +1,107 @@
+package pods
+
+import (
+	"testing"
+
+	"github.com/kubewall/kubewall/backend/handlers/base"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func testPodsHandler() *PodsHandler {
+	return &PodsHandler{
+		BaseHandler: base.BaseHandler{
+			QueryConfig:  "cfg",
+			QueryCluster: "clu",
+		},
+		ownerStreams: base.NewOwnerStreams(),
+	}
+}
+
+func ownedPod(namespace string, owners ...metaV1.OwnerReference) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:            "pod",
+			Namespace:       namespace,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func TestOwnerPodsStreamID(t *testing.T) {
+	t.Run("namespace separates same-named workloads", func(t *testing.T) {
+		staging := OwnerPodsStreamID("cfg", "clu", JobsResource, "staging", "nightly-report")
+		prod := OwnerPodsStreamID("cfg", "clu", JobsResource, "prod", "nightly-report")
+
+		assert.NotEqual(t, staging, prod)
+	})
+
+	t.Run("resource separates workloads of different kinds", func(t *testing.T) {
+		job := OwnerPodsStreamID("cfg", "clu", JobsResource, "default", "shared-name")
+		statefulSet := OwnerPodsStreamID("cfg", "clu", StatefulSetsResource, "default", "shared-name")
+
+		assert.NotEqual(t, job, statefulSet)
+	})
+}
+
+func TestOwnerPodsStreamIDs(t *testing.T) {
+	h := testPodsHandler()
+
+	t.Run("maps a pod onto its controller's stream", func(t *testing.T) {
+		pod := ownedPod("default", metaV1.OwnerReference{Kind: "Job", Name: "backfill"})
+
+		assert.Equal(t,
+			[]string{OwnerPodsStreamID("cfg", "clu", JobsResource, "default", "backfill")},
+			h.ownerPodsStreamIDs(pod),
+		)
+	})
+
+	t.Run("keys on the pod's namespace, which its controller shares", func(t *testing.T) {
+		pod := ownedPod("staging", metaV1.OwnerReference{Kind: "Job", Name: "backfill"})
+
+		assert.Equal(t,
+			[]string{OwnerPodsStreamID("cfg", "clu", JobsResource, "staging", "backfill")},
+			h.ownerPodsStreamIDs(pod),
+		)
+	})
+
+	t.Run("covers every workload kind that has a pod list", func(t *testing.T) {
+		for kind, resource := range map[string]string{
+			"Job":         JobsResource,
+			"DaemonSet":   DaemonSetsResource,
+			"StatefulSet": StatefulSetsResource,
+			"ReplicaSet":  ReplicaSetsResource,
+		} {
+			pod := ownedPod("default", metaV1.OwnerReference{Kind: kind, Name: "owner"})
+
+			assert.Equal(t,
+				[]string{OwnerPodsStreamID("cfg", "clu", resource, "default", "owner")},
+				h.ownerPodsStreamIDs(pod),
+				kind,
+			)
+		}
+	})
+
+	t.Run("a Deployment's pods reach its ReplicaSet, not the Deployment", func(t *testing.T) {
+		// A Deployment owns pods only through a ReplicaSet. The ReplicaSet stream
+		// is what a ReplicaSet details view reads; DeploymentsPods separately walks
+		// the extra hop up to the Deployment.
+		pod := ownedPod("default", metaV1.OwnerReference{Kind: "ReplicaSet", Name: "web-7d9f"})
+
+		assert.Equal(t,
+			[]string{OwnerPodsStreamID("cfg", "clu", ReplicaSetsResource, "default", "web-7d9f")},
+			h.ownerPodsStreamIDs(pod),
+		)
+	})
+
+	t.Run("ignores an owner kind with no pod list of its own", func(t *testing.T) {
+		pod := ownedPod("default", metaV1.OwnerReference{Kind: "Deployment", Name: "web"})
+
+		assert.Empty(t, h.ownerPodsStreamIDs(pod))
+	})
+
+	t.Run("ignores a pod with no controller at all", func(t *testing.T) {
+		assert.Empty(t, h.ownerPodsStreamIDs(ownedPod("default")))
+	})
+}

--- a/backend/handlers/workloads/pods/pods.go
+++ b/backend/handlers/workloads/pods/pods.go
@@ -34,6 +34,7 @@ type PodsHandler struct {
 	clientSet         *kubernetes.Clientset
 	restConfig        *rest.Config
 	replicasetHandler *replicaset.ReplicaSetHandler
+	ownerStreams      *base.OwnerStreams
 }
 
 func NewPodsRouteHandler(container container.Container, routeType base.RouteType) echo.HandlerFunc {
@@ -87,6 +88,7 @@ func newPodsHandler(ctx context.Context, config, cluster string, container conta
 		restConfig:        container.RestConfig(config, cluster),
 		clientSet:         clientSet,
 		replicasetHandler: replicaset.NewReplicaSetHandler(ctx, config, cluster, container),
+		ownerStreams:      base.NewOwnerStreams(),
 	}
 
 	additionalEvents := []map[string]func(){
@@ -94,6 +96,7 @@ func newPodsHandler(ctx context.Context, config, cluster string, container conta
 			"pods-deployments": func() {
 				go handler.DeploymentsPods()
 				go handler.NodePods()
+				go handler.OwnerPods()
 			},
 		},
 	}

--- a/backend/routes/routes.go
+++ b/backend/routes/routes.go
@@ -279,6 +279,7 @@ func workloadRoutes(e *echo.Echo, appContainer container.Container) {
 	e.GET("api/v1/daemonsets/:name", daemonsets.NewDaemonSetsRouteHandler(appContainer, base.GetDetails)).Name = "daemonsetsDetails"
 	e.GET("api/v1/daemonsets/:name/yaml", daemonsets.NewDaemonSetsRouteHandler(appContainer, base.GetYaml)).Name = "daemonsetsYaml"
 	e.GET("api/v1/daemonsets/:name/events", daemonsets.NewDaemonSetsRouteHandler(appContainer, base.GetEvents)).Name = "daemonsetsEvents"
+	e.GET("api/v1/daemonsets/:name/pods", pods.NewOwnerPodsRouteHandler(appContainer, pods.DaemonSetsResource)).Name = "daemonsetsPods"
 	e.DELETE("api/v1/daemonsets", daemonsets.NewDaemonSetsRouteHandler(appContainer, base.Delete)).Name = "daemonsetsDelete"
 
 	// ReplicaSets
@@ -286,6 +287,7 @@ func workloadRoutes(e *echo.Echo, appContainer container.Container) {
 	e.GET("api/v1/replicasets/:name", replicaset.NewReplicaSetRouteHandler(appContainer, base.GetDetails)).Name = "replicasetsDetails"
 	e.GET("api/v1/replicasets/:name/yaml", replicaset.NewReplicaSetRouteHandler(appContainer, base.GetYaml)).Name = "replicasetsYaml"
 	e.GET("api/v1/replicasets/:name/events", replicaset.NewReplicaSetRouteHandler(appContainer, base.GetEvents)).Name = "replicasetsEvents"
+	e.GET("api/v1/replicasets/:name/pods", pods.NewOwnerPodsRouteHandler(appContainer, pods.ReplicaSetsResource)).Name = "replicasetsPods"
 	e.DELETE("api/v1/replicasets", replicaset.NewReplicaSetRouteHandler(appContainer, base.Delete)).Name = "replicasetsDelete"
 
 	// StatefulSets
@@ -293,6 +295,7 @@ func workloadRoutes(e *echo.Echo, appContainer container.Container) {
 	e.GET("api/v1/statefulsets/:name", statefulset.NewStatefulSetRouteHandler(appContainer, base.GetDetails)).Name = "statefulsetsDetails"
 	e.GET("api/v1/statefulsets/:name/yaml", statefulset.NewStatefulSetRouteHandler(appContainer, base.GetYaml)).Name = "statefulsetsYaml"
 	e.GET("api/v1/statefulsets/:name/events", statefulset.NewStatefulSetRouteHandler(appContainer, base.GetEvents)).Name = "statefulsetsEvents"
+	e.GET("api/v1/statefulsets/:name/pods", pods.NewOwnerPodsRouteHandler(appContainer, pods.StatefulSetsResource)).Name = "statefulsetsPods"
 	e.DELETE("api/v1/statefulsets", statefulset.NewStatefulSetRouteHandler(appContainer, base.Delete)).Name = "statefulsetsDelete"
 
 	// Jobs
@@ -300,6 +303,7 @@ func workloadRoutes(e *echo.Echo, appContainer container.Container) {
 	e.GET("api/v1/jobs/:name", jobs.NewJobsRouteHandler(appContainer, base.GetDetails)).Name = "jobsDetails"
 	e.GET("api/v1/jobs/:name/yaml", jobs.NewJobsRouteHandler(appContainer, base.GetYaml)).Name = "jobsYaml"
 	e.GET("api/v1/jobs/:name/events", jobs.NewJobsRouteHandler(appContainer, base.GetEvents)).Name = "jobsEvents"
+	e.GET("api/v1/jobs/:name/pods", pods.NewOwnerPodsRouteHandler(appContainer, pods.JobsResource)).Name = "jobsPods"
 	e.DELETE("api/v1/jobs", jobs.NewJobsRouteHandler(appContainer, base.Delete)).Name = "jobsDelete"
 
 	// CronJobs
@@ -307,6 +311,7 @@ func workloadRoutes(e *echo.Echo, appContainer container.Container) {
 	e.GET("api/v1/cronjobs/:name", cronjobs.NewCronJobsRouteHandler(appContainer, base.GetDetails)).Name = "cronjobsDetails"
 	e.GET("api/v1/cronjobs/:name/yaml", cronjobs.NewCronJobsRouteHandler(appContainer, base.GetYaml)).Name = "cronjobsYaml"
 	e.GET("api/v1/cronjobs/:name/events", cronjobs.NewCronJobsRouteHandler(appContainer, base.GetEvents)).Name = "cronjobsEvents"
+	e.GET("api/v1/cronjobs/:name/jobs", cronjobs.NewCronJobsRouteHandler(appContainer, cronjobs.GetJobs)).Name = "cronjobsJobs"
 	e.DELETE("api/v1/cronjobs", cronjobs.NewCronJobsRouteHandler(appContainer, base.Delete)).Name = "cronjobsDelete"
 }
 

--- a/client/src/components/app/Common/Hooks/Details/detailsWrapper.tsx
+++ b/client/src/components/app/Common/Hooks/Details/detailsWrapper.tsx
@@ -1,5 +1,5 @@
 import { CLUSTER_ROLES_ENDPOINT, CLUSTER_ROLE_BINDINGS_ENDPOINT, CONFIG_MAPS_ENDPOINT, CRON_JOBS_ENDPOINT, CUSTOM_RESOURCES_ENDPOINT, CUSTOM_RESOURCES_LIST_ENDPOINT, DAEMON_SETS_ENDPOINT, DEPLOYMENT_ENDPOINT, ENDPOINTS_ENDPOINT, HPA_ENDPOINT, INGRESSES_ENDPOINT, JOBS_ENDPOINT, LEASES_ENDPOINT, LIMIT_RANGE_ENDPOINT, NAMESPACES_ENDPOINT, NODES_ENDPOINT, PERSISTENT_VOLUMES_ENDPOINT, PERSISTENT_VOLUME_CLAIMS_ENDPOINT, PODS_ENDPOINT, POD_DISRUPTION_BUDGETS_ENDPOINT, PRIORITY_CLASSES_ENDPOINT, REPLICA_SETS_ENDPOINT, RESOURCE_QUOTAS_ENDPOINT, ROLES_ENDPOINT, ROLE_BINDINGS_ENDPOINT, RUNTIME_CLASSES_ENDPOINT, SECRETS_ENDPOINT, SERVICES_ENDPOINT, SERVICE_ACCOUNTS_ENDPOINT, STATEFUL_SETS_ENDPOINT, STORAGE_CLASSES_ENDPOINT } from "@/constants";
-import { ClusterRoleBindingDetailsContainer, ClusterRoleDetailsContainer, ConfigMapDetailsContainer, CustomResourceDetailsContainer, DeploymentDetailsContainer, EndpointDetailsContainer, LimitRangeDetailsContainer, NamespaceDetailsContainer, NodeDetailsContainer, PodDetailsContainer, PodDisruptionBudgetDetailsContainer, ResourceQuotaDetailsContainer, RoleBindingDetailsContainer, RoleDetailsContainer, RuntimeClassDetailsContainer, SecretDetailsContainer, ServiceAccountDetailsContainer, ServiceDetailsContainer } from "@/components/app/MiscDetailsContainer";
+import { ClusterRoleBindingDetailsContainer, ClusterRoleDetailsContainer, ConfigMapDetailsContainer, CronJobJobsList, CustomResourceDetailsContainer, DeploymentDetailsContainer, EndpointDetailsContainer, LimitRangeDetailsContainer, NamespaceDetailsContainer, NodeDetailsContainer, PodDetailsContainer, PodDisruptionBudgetDetailsContainer, ResourceQuotaDetailsContainer, RoleBindingDetailsContainer, RoleDetailsContainer, RuntimeClassDetailsContainer, SecretDetailsContainer, ServiceAccountDetailsContainer, ServiceDetailsContainer, WorkloadPodsList } from "@/components/app/MiscDetailsContainer";
 import { getClusterRoleBindingDetailsConfig, getClusterRoleDetailsConfig, getConfigMapDetailsConfig, getCronJobsDetailsConfig, getCustomResourceDefinitionsDetailsConfig, getCustomResourceDetailsConfig, getDaemonSetDetailsConfig, getDeploymentDetailsConfig, getEndpointDetailsConfig, getHPADetailsConfig, getIngressDetailsConfig, getJobsDetailsConfig, getLeaseDetailsConfig, getLimitRangeDetailsConfig, getNamespaceDetailsConfig, getNodeDetailsConfig, getPersistentVolumeClaimDetailsConfig, getPersistentVolumeDetailsConfig, getPodDetailsConfig, getPodDisruptionBudgetDetailsConfig, getPriorityClassDetailsConfig, getReplicaSetDetailsConfig, getResourceQuotaDetailsConfig, getRoleBindingDetailsConfig, getRoleDetailsConfig, getRuntimeClassDetailsConfig, getSecretDetailsConfig, getServiceAccountDetailsConfig, getServiceDetailsConfig, getStatefulSetDetailsConfig, getStorageClassDetailsConfig } from "@/utils/DetailType/DetailDefinations";
 
 import { RootState } from "@/redux/store";
@@ -61,19 +61,19 @@ const useDetailsWrapper = ({ loading, resourcekind }: DetailsWapperProps) => {
     return { ...getDeploymentDetailsConfig(deploymentDetails, loading), miscComponent: <DeploymentDetailsContainer/> };
   }
   if (resourcekind === DAEMON_SETS_ENDPOINT) {
-    return { ...getDaemonSetDetailsConfig(daemonSetDetails, loading), miscComponent: <></> };
+    return { ...getDaemonSetDetailsConfig(daemonSetDetails, loading), miscComponent: <WorkloadPodsList endpoint={DAEMON_SETS_ENDPOINT}/> };
   }
   if (resourcekind === STATEFUL_SETS_ENDPOINT) {
-    return { ...getStatefulSetDetailsConfig(statefulSetDetails, loading), miscComponent: <></> };
+    return { ...getStatefulSetDetailsConfig(statefulSetDetails, loading), miscComponent: <WorkloadPodsList endpoint={STATEFUL_SETS_ENDPOINT}/> };
   }
   if (resourcekind === REPLICA_SETS_ENDPOINT) {
-    return { ...getReplicaSetDetailsConfig(replicaSetDetails, loading), miscComponent: <></> };
+    return { ...getReplicaSetDetailsConfig(replicaSetDetails, loading), miscComponent: <WorkloadPodsList endpoint={REPLICA_SETS_ENDPOINT}/> };
   }
   if (resourcekind === JOBS_ENDPOINT) {
-    return { ...getJobsDetailsConfig(jobDetails, loading), miscComponent: <></> };
+    return { ...getJobsDetailsConfig(jobDetails, loading), miscComponent: <WorkloadPodsList endpoint={JOBS_ENDPOINT}/> };
   }
   if (resourcekind === CRON_JOBS_ENDPOINT) {
-    return { ...getCronJobsDetailsConfig(cronJobDetails, loading), miscComponent: <></> };
+    return { ...getCronJobsDetailsConfig(cronJobDetails, loading), miscComponent: <CronJobJobsList/> };
   }
   if (resourcekind === SECRETS_ENDPOINT) {
     return { ...getSecretDetailsConfig(secretsDetails, loading), miscComponent: <SecretDetailsContainer/> };

--- a/client/src/components/app/Common/Hooks/TableColumns/index.tsx
+++ b/client/src/components/app/Common/Hooks/TableColumns/index.tsx
@@ -1,4 +1,4 @@
-import { ClusterDetails, HeaderList, TableColumns } from '@/types';
+import { HeaderList, TableColumns } from '@/types';
 
 import { ColumnDef } from '@tanstack/react-table';
 import { DefaultHeader } from '@/components/app/Table';
@@ -67,7 +67,11 @@ function getColumnWidth(title: string): number {
   }
 }
 
-function GenerateColumns<T extends ClusterDetails, C extends HeaderList>({
+// T is only ever the row type handed straight back to react-table; the cluster
+// and config names come from the props below, not off the row. Leaving it
+// unconstrained lets real row types be used - the ones that model a list's
+// columns and nothing else.
+function GenerateColumns<T, C extends HeaderList>({
   count,
   clusterName,
   configName,

--- a/client/src/components/app/MiscDetailsContainer/CronJobs/CronJobJobsList.tsx
+++ b/client/src/components/app/MiscDetailsContainer/CronJobs/CronJobJobsList.tsx
@@ -1,0 +1,91 @@
+import { CRON_JOBS_ENDPOINT, JOBS_ENDPOINT } from "@/constants";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { HeaderList, Jobs, JobsResponse } from "@/types";
+import { createEventStreamQueryObject, defaultSkeletonRow, getEventStreamUrl } from "@/utils";
+import { memo, useEffect } from "react";
+import { resetCronJobJobs, updateCronJobJobs } from "@/data/Workloads/CronJobs/CronJobJobsSlice";
+import { useAppDispatch, useAppSelector } from "@/redux/hooks";
+
+import { DataTable } from "@/components/app/Table";
+import { RootState } from "@/redux/store";
+import { cn } from "@/lib/utils";
+import { jobsColumnConfig } from "@/utils/ListType/ListDefinations";
+import { kwDetails } from "@/routes";
+import { useEventSource } from "@/components/app/Common/Hooks/EventSource";
+import useGenerateColumns from "@/components/app/Common/Hooks/TableColumns";
+import { useSidebar } from "@/components/ui/sidebar";
+
+const CronJobJobsList = memo(function () {
+  const { config } = kwDetails.useParams();
+  const { cluster, resourcename, namespace } = kwDetails.useSearch();
+  const {
+    loading,
+    cronJobJobDetails
+  } = useAppSelector((state: RootState) => state.cronJobJobs);
+  const { open } = useSidebar();
+  const dispatch = useAppDispatch();
+
+  const sendMessage = (message: JobsResponse[]) => {
+    dispatch(updateCronJobJobs(message));
+  };
+
+  useEventSource({
+    url: getEventStreamUrl(
+      CRON_JOBS_ENDPOINT,
+      createEventStreamQueryObject(
+        config,
+        cluster,
+        namespace
+      ),
+      `/${resourcename}/jobs`
+    ),
+    sendMessage
+  });
+
+  // Clear on the way out so navigating to another CronJob shows skeleton rows
+  // rather than the previous one's jobs until its first event arrives.
+  useEffect(() => {
+    return () => {
+      dispatch(resetCronJobJobs());
+    };
+  }, [dispatch, resourcename, namespace]);
+
+  return (
+    <div className="mt-2">
+      <Card className="rounded-lg shadow-none">
+        <CardHeader className="p-4">
+          <CardTitle className="text-sm font-medium">Jobs <span className="text-xs">({cronJobJobDetails.length})</span></CardTitle>
+        </CardHeader>
+        <CardContent className="pl-4 pr-4">
+          <div className="col-span-7">
+            <div className="h-full">
+              <DataTable
+                columns={
+                  useGenerateColumns<Jobs, HeaderList>({
+                    clusterName: cluster,
+                    configName: config,
+                    loading,
+                    headersList: jobsColumnConfig(config, cluster, false).headersList,
+                    instanceType: JOBS_ENDPOINT,
+                    count: cronJobJobDetails.length,
+                  })
+                }
+                data={loading ? defaultSkeletonRow() : cronJobJobDetails}
+                tableWidthCss={cn("rounded-md border-r rounded-md border-l", open ? 'deployment-list-table-max-width-expanded' : 'deployment-list-table-max-width-collapsed')}
+                instanceType={JOBS_ENDPOINT}
+                showToolbar={false}
+                showNamespaceFilter={false}
+                setShowChat={() => { }}
+                showChat={false}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+});
+
+export {
+  CronJobJobsList
+};

--- a/client/src/components/app/MiscDetailsContainer/Workloads/WorkloadPodsList.tsx
+++ b/client/src/components/app/MiscDetailsContainer/Workloads/WorkloadPodsList.tsx
@@ -1,0 +1,99 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { HeaderList, Pods } from "@/types";
+import { createEventStreamQueryObject, defaultSkeletonRow, getEventStreamUrl } from "@/utils";
+import { memo, useEffect } from "react";
+import { resetWorkloadPods, updateWorkloadPods } from "@/data/Workloads/WorkloadPodsSlice";
+import { useAppDispatch, useAppSelector } from "@/redux/hooks";
+
+import { DataTable } from "@/components/app/Table";
+import { PODS_ENDPOINT } from "@/constants";
+import { RootState } from "@/redux/store";
+import { cn } from "@/lib/utils";
+import { kwDetails } from "@/routes";
+import { podsColumnConfig } from "@/utils/ListType/ListDefinations";
+import { useEventSource } from "@/components/app/Common/Hooks/EventSource";
+import useGenerateColumns from "@/components/app/Common/Hooks/TableColumns";
+import { useSidebar } from "@/components/ui/sidebar";
+
+type WorkloadPodsListProps = {
+  /**
+   * Endpoint of the workload being viewed - the pods it owns are served under
+   * `<endpoint>/<name>/pods`.
+   */
+  endpoint: string;
+};
+
+const WorkloadPodsList = memo(function ({ endpoint }: WorkloadPodsListProps) {
+  const { config } = kwDetails.useParams();
+  const { cluster, resourcename, namespace } = kwDetails.useSearch();
+  const {
+    loading,
+    workloadPodDetails
+  } = useAppSelector((state: RootState) => state.workloadPods);
+  const { open } = useSidebar();
+  const dispatch = useAppDispatch();
+
+  const sendMessage = (message: Pods[]) => {
+    dispatch(updateWorkloadPods(message));
+  };
+
+  useEventSource({
+    url: getEventStreamUrl(
+      endpoint,
+      createEventStreamQueryObject(
+        config,
+        cluster,
+        namespace
+      ),
+      `/${resourcename}/pods`
+    ),
+    sendMessage
+  });
+
+  // Clear on the way out so navigating to another workload shows skeleton rows
+  // rather than the previous workload's pods until its first event arrives.
+  useEffect(() => {
+    return () => {
+      dispatch(resetWorkloadPods());
+    };
+  }, [dispatch, endpoint, resourcename, namespace]);
+
+  return (
+    <div className="mt-2">
+      <Card className="rounded-lg shadow-none">
+        <CardHeader className="p-4">
+          <CardTitle className="text-sm font-medium">Pods <span className="text-xs">({workloadPodDetails.length})</span></CardTitle>
+        </CardHeader>
+        <CardContent className="pl-4 pr-4">
+          <div className="col-span-7">
+            <div className="h-full">
+              <DataTable
+                columns={
+                  useGenerateColumns<Pods, HeaderList>({
+                    clusterName: cluster,
+                    configName: config,
+                    loading,
+                    headersList: podsColumnConfig(config, cluster, false).headersList,
+                    instanceType: PODS_ENDPOINT,
+                    count: workloadPodDetails.length,
+                  })
+                }
+                data={loading ? defaultSkeletonRow() : workloadPodDetails}
+                tableWidthCss={cn("rounded-md border-r rounded-md border-l", open ? 'deployment-list-table-max-width-expanded' : 'deployment-list-table-max-width-collapsed')}
+                instanceType={PODS_ENDPOINT}
+                showToolbar={false}
+                showNamespaceFilter={false}
+                setShowChat={() => { }}
+                showChat={false}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+});
+
+export {
+  WorkloadPodsList
+};

--- a/client/src/components/app/MiscDetailsContainer/index.tsx
+++ b/client/src/components/app/MiscDetailsContainer/index.tsx
@@ -12,6 +12,8 @@ export * from './SecretDetailsContainer';
 export * from './EndpointDetailsContainer';
 export * from './ServiceDetailsContainer';
 export * from './Deployments/DeploymentDetailsContainer';
+export * from './Workloads/WorkloadPodsList';
+export * from './CronJobs/CronJobJobsList';
 export * from './Deployments/ScaleDeployments';
 export * from './PodDetailsContainer';
 export * from './ServiceAccountDetailsContainer';

--- a/client/src/components/app/Table/TableCells/index.tsx
+++ b/client/src/components/app/Table/TableCells/index.tsx
@@ -25,7 +25,7 @@ type TableCellType<T> = {
   queryParams?: string;
 } & ClusterDetails;
 
-const TableCells = <T extends ClusterDetails>({
+const TableCells = <T,>({
   clusterName,
   configName,
   instanceType,

--- a/client/src/components/app/Table/data-table.tsx
+++ b/client/src/components/app/Table/data-table.tsx
@@ -34,6 +34,7 @@ import { TableDelete } from './TableDelete';
 import { useFittedColumnWidths } from "@/hooks/use-fitted-column-widths";
 import { resetListTableFilter } from "@/data/Misc/ListTableFilterSlice";
 import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { useVirtualizer } from "@tanstack/react-virtual";
 
 // Rows are single-line and fairly uniform; this is just a starting estimate -
@@ -222,7 +223,14 @@ export function DataTable<TData, TValue>({
           !fullScreen &&
           <ResizablePanel id="table" order={1} defaultSize={showChat ? 55 : 100}>
             <div className="relative h-full">
-            <div ref={tableContainerRef} className={`border border-x-0 overflow-auto ${tableWidthCss} `}>
+            {/* The empty state is an overlay pinned below the header, so it needs the
+                container to have height. The full-page list sets one; the tables
+                embedded in a details card set width only and would otherwise
+                collapse to the header row, squeezing the message under it. */}
+            <div
+              ref={tableContainerRef}
+              className={cn('border border-x-0 overflow-auto', tableWidthCss, !rows.length && 'min-h-40')}
+            >
               <TooltipProvider delayDuration={0}>
               <Table style={{ tableLayout: 'fixed' }}>
                 <TableHeader className="sticky top-0 z-10 bg-muted">
@@ -304,7 +312,7 @@ export function DataTable<TData, TValue>({
                         </Button>
                       </>
                     ) : (
-                      <p>No {getSearchTarget(instanceType, kind)} found in cluster.</p>
+                      <p className="text-sm text-muted-foreground">No {getSearchTarget(instanceType, kind)} found in cluster.</p>
                     )}
                   </div>
                 </div>

--- a/client/src/data/Workloads/CronJobs/CronJobJobsSlice.ts
+++ b/client/src/data/Workloads/CronJobs/CronJobJobsSlice.ts
@@ -1,0 +1,38 @@
+import { Jobs } from '@/types';
+import { RawRequestError } from '../../kwFetch';
+import { createSlice } from '@reduxjs/toolkit';
+import { formatJobsResponse } from '@/utils';
+import { resetAllStates } from '@/redux/hooks';
+
+type InitialState = {
+  loading: boolean;
+  cronJobJobDetails: Jobs[];
+  error: RawRequestError | null,
+};
+
+const initialState: InitialState = {
+  loading: true,
+  cronJobJobDetails: [] as Jobs[],
+  error: null,
+};
+
+const cronJobJobsSlice = createSlice({
+  name: 'cronJobJobs',
+  initialState,
+  reducers: {
+    updateCronJobJobs: (state, action) => {
+      state.cronJobJobDetails = formatJobsResponse(action.payload);
+      state.loading = false;
+    },
+    resetCronJobJobs: () => {
+      return initialState;
+    }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetAllStates, () => initialState);
+  },
+});
+
+const { updateCronJobJobs, resetCronJobJobs } = cronJobJobsSlice.actions;
+export default cronJobJobsSlice.reducer;
+export { initialState, updateCronJobJobs, resetCronJobJobs };

--- a/client/src/data/Workloads/WorkloadPodsSlice.ts
+++ b/client/src/data/Workloads/WorkloadPodsSlice.ts
@@ -1,0 +1,43 @@
+import { Pods } from '@/types';
+import { RawRequestError } from '../kwFetch';
+import { createSlice } from '@reduxjs/toolkit';
+import { resetAllStates } from '@/redux/hooks';
+
+type InitialState = {
+  loading: boolean;
+  workloadPodDetails: Pods[];
+  error: RawRequestError | null,
+};
+
+const initialState: InitialState = {
+  loading: true,
+  workloadPodDetails: [] as Pods[],
+  error: null,
+};
+
+// Backs the pod list on the Job, DaemonSet and StatefulSet details views. One
+// slice serves all three because only one details view is mounted at a time, and
+// the list it holds is scoped by the stream the mounted view subscribes to.
+const workloadPodsSlice = createSlice({
+  name: 'workloadPods',
+  initialState,
+  reducers: {
+    updateWorkloadPods: (state, action) => {
+      state.workloadPodDetails = action.payload.map((pod: Pods) => ({
+        ...pod,
+        ...(pod.memory ? { memory: `${pod.memory} MiB` } : {})
+      }));
+      state.loading = false;
+    },
+    resetWorkloadPods: () => {
+      return initialState;
+    }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(resetAllStates, () => initialState);
+  },
+});
+
+const { updateWorkloadPods, resetWorkloadPods } = workloadPodsSlice.actions;
+export default workloadPodsSlice.reducer;
+export { initialState, updateWorkloadPods, resetWorkloadPods };

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -43,7 +43,9 @@ import namespaceDetailsSlice from '@/data/Clusters/Namespaces/NamespaceDetailsSl
 import namespacesSlice from '@/data/Clusters/Namespaces/NamespacesSlice';
 import nodeDetailsSlice from '@/data/Clusters/Nodes/NodeDetailsSlice';
 import nodeListSlice from '@/data/Clusters/Nodes/NodeListSlice';
+import cronJobJobsSlice from '@/data/Workloads/CronJobs/CronJobJobsSlice';
 import nodePodsSlice from '@/data/Clusters/Nodes/NodePodsSlice';
+import workloadPodsSlice from '@/data/Workloads/WorkloadPodsSlice';
 import persistentVolumeClaimsDetailsSlice from '@/data/Storages/PersistentVolumeClaims/PersistentVolumeClaimDetailsSlice';
 import persistentVolumeClaimsListSlice from '@/data/Storages/PersistentVolumeClaims/PersistentVolumeClaimsListSlice';
 import persistentVolumeDetailsSlice from '@/data/Storages/PersistentVolumes/PersistentVolumeDetailsSlice';
@@ -177,6 +179,8 @@ const store = configureStore({
     portForwarding: portForwardingSlice,
     portForwardingList: portForwardingListSlice,
     nodePods: nodePodsSlice,
+    workloadPods: workloadPodsSlice,
+    cronJobJobs: cronJobJobsSlice,
     ...addonReducers,
   },
 });

--- a/client/src/utils/ListType/ListDefinations.ts
+++ b/client/src/utils/ListType/ListDefinations.ts
@@ -422,7 +422,7 @@ const deploymentsColumnConfig = (config: string, cluster: string) => ({
   showNamespaceFilter: true
 });
 
-const jobsColumnConfig = (config: string, cluster: string) => ({
+const jobsColumnConfig = (config: string, cluster: string, isSelectable = true) => ({
   headersList: [
     { title: 'Select', accessorKey: 'select', enableSorting: false, },
     { title: 'Namespace', accessorKey: 'namespace', enableGlobalFilter: true },
@@ -431,7 +431,7 @@ const jobsColumnConfig = (config: string, cluster: string) => ({
     { title: 'Conditions', accessorKey: 'conditions' },
     { title: 'Duration', accessorKey: 'duration' },
     { title: 'Age', accessorKey: 'age' }
-  ],
+  ].filter(({ title }) => isSelectable || (!isSelectable && title.toLowerCase() !== 'select')),
   queryParams: { config, cluster },
   showNamespaceFilter: true
 });


### PR DESCRIPTION

- Implemented CronJobJobs functionality in backend to publish job lists for CronJobs.
- Created tests for CronJobJobs functionality to ensure correct mapping and streaming.
- Added OwnerPods functionality to handle pods for various workloads including Jobs, DaemonSets, StatefulSets, and ReplicaSets.
- Developed frontend components for displaying CronJob jobs and workload pods, including event streaming for real-time updates.
- Updated Redux slices to manage state for CronJob jobs and workload pods.
- Enhanced routing to support new endpoints for fetching pods associated with workloads.
- Refactored table column configurations to accommodate new data structures.

**CRON Jobs**

<img width="1454" height="618" alt="image" src="https://github.com/user-attachments/assets/a5a92ff9-385d-4a30-9860-37d5e147ab60" />

**Jobs**

<img width="1458" height="926" alt="image" src="https://github.com/user-attachments/assets/93df5bcf-0ba5-4323-a7f7-e558e09b3f71" />

fixes: #188 
