### PR TITLE
fix: enhance kubernetes namespace filtering and search feedback in DataTable

### DIFF
--- a/client/src/components/app/Common/ResourceDetailsLink/index.tsx
+++ b/client/src/components/app/Common/ResourceDetailsLink/index.tsx
@@ -1,0 +1,45 @@
+import { DetailsCardLink } from "@/types";
+import { Link } from "@tanstack/react-router";
+import { RootState } from "@/redux/store";
+import { kwDetails } from "@/routes";
+import { toQueryParams } from "@/utils";
+import { useAppSelector } from "@/redux/hooks";
+
+type ResourceDetailsLinkProps = {
+  link: DetailsCardLink;
+  text: string;
+};
+
+function ResourceDetailsLink({ link, text }: ResourceDetailsLinkProps) {
+  const { config } = kwDetails.useParams();
+  const { cluster } = kwDetails.useSearch();
+  const customResourcesNavigation = useAppSelector((state: RootState) => state.customResources.customResourcesNavigation);
+
+  const { customResource } = link;
+  const customResourceDefinition = customResource
+    ? customResourcesNavigation[customResource.group]?.resources.find(({ name }) => name === customResource.kind)
+    : undefined;
+
+  if (customResource && !customResourceDefinition) {
+    return <>{text}</>;
+  }
+
+  const namespace = customResourceDefinition && customResourceDefinition.scope !== 'Namespaced' ? '' : link.namespace;
+  const queryParams = toQueryParams({
+    cluster,
+    resourcekind: link.resourcekind,
+    resourcename: link.resourcename,
+    ...(namespace ? { namespace } : {})
+  });
+  const customResourceParams = customResourceDefinition ? `&${customResourceDefinition.route}` : '';
+
+  return (
+    <Link to={`/${config}/details?${queryParams}${customResourceParams}`} className="text-blue-600 dark:text-blue-500 hover:underline">
+      {text}
+    </Link>
+  );
+}
+
+export {
+  ResourceDetailsLink
+};

--- a/client/src/components/app/Details/Card/FixedCard/index.tsx
+++ b/client/src/components/app/Details/Card/FixedCard/index.tsx
@@ -1,19 +1,30 @@
 import { Card, CardContent, CardTitle } from "@/components/ui/card";
 
 import { CopyToClipboard } from "@/components/app/Common/CopyToClipboard";
+import { DetailsCards } from "@/types";
 import { RelativeTime } from "@/components/app/Common/RelativeTime";
+import { ResourceDetailsLink } from "@/components/app/Common/ResourceDetailsLink";
 
 type CardContainerProps = {
-  items: {
-    label: string,
-    value: string | number | boolean,
-  }[],
+  items: DetailsCards,
   title?: string;
 };
 
 const AGE_LABEL = 'Age';
 
+function DetailValue({ label, value, link }: DetailsCards[number]) {
+  if (link) {
+    return <ResourceDetailsLink link={link} text={String(value)} />;
+  }
+  if (label === AGE_LABEL && typeof value === 'string' && !Number.isNaN(Date.parse(value))) {
+    return <RelativeTime timestamp={value} />;
+  }
+  return <>{value}</>;
+}
+
 export function FixedCard({ items, title }: CardContainerProps) {
+  const rowsPerColumn = Math.ceil(items.length / 2);
+
   return (
     <div className="flex items-center justify-center [&>div]:w-full">
       <Card className="pt-3 shadow-none rounded-lg">
@@ -21,20 +32,19 @@ export function FixedCard({ items, title }: CardContainerProps) {
           title && <CardTitle className="p-4">{title}</CardTitle>
         }
         <CardContent className="grid gap-1 p-4 pt-0">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+          <div
+            className="grid grid-cols-1 gap-2 md:grid-cols-2 md:grid-flow-col"
+            style={{ gridTemplateRows: `repeat(${rowsPerColumn}, auto)` }}
+          >
             {
-              items.map(({ label, value }) => {
-                const timestamp = label === AGE_LABEL && typeof value === 'string' && !Number.isNaN(Date.parse(value))
-                  ? value
-                  : null;
-
+              items.map(({ label, value, link }) => {
                 return (
                   <div key={label} className="group/item -mx-2 px-3 transition-all">
                     <div className="flex flex-row">
                       <div className="text-sm font-medium text-muted-foreground basis-1/3">{label}</div>
                       {/* <div className="text-sm font-normal break-all basis-2/3">{value}</div> */}
                       <div className="text-sm font-normal basis-2/3 flex items-center justify-between">
-                        <div className="break-all">{timestamp ? <RelativeTime timestamp={timestamp} /> : value}</div>
+                        <div className="break-all"><DetailValue label={label} value={value} link={link} /></div>
                         <div className="group/edit invisible group-hover/item:visible">
                           <CopyToClipboard val={value}/>
                           {/* <CopyIcon

--- a/client/src/components/app/Details/Events/index.tsx
+++ b/client/src/components/app/Details/Events/index.tsx
@@ -56,6 +56,7 @@ export function Events({ instanceType, name, namespace, configName, clusterName,
       columns={eventsColumns({ count: events.length, clusterName, configName, loading, instanceType: 'events' })}
       data={events}
       showToolbar={false}
+      emptyMessage={`No events for ${name}.`}
       tableWidthCss="event-table-max-height rounded-lg"
       instanceType='events'
       showNamespaceFilter={false}

--- a/client/src/components/app/MiscDetailsContainer/PortForwarding.tsx
+++ b/client/src/components/app/MiscDetailsContainer/PortForwarding.tsx
@@ -1,5 +1,5 @@
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { PlugZap, UnplugIcon, XIcon } from "lucide-react";
+import { Dices, PlugZap, UnplugIcon, XIcon } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { portForwarding, resetPortForwarding } from "@/data/Workloads/Pods/PortForwardingSlice";
@@ -11,6 +11,9 @@ import { Link } from "@tanstack/react-router";
 import { Loader } from "../Loader";
 import { toast } from "sonner";
 import { useAppDispatch } from "@/redux/hooks";
+
+const RANDOM_LOCAL_PORT_MIN = 10000;
+const RANDOM_LOCAL_PORT_MAX = 65535;
 
 type PortForwardingDialogProps = {
   resourcename: string;
@@ -65,6 +68,15 @@ export function PortForwardingDialog({
     }
     if (id === 'localPort') setValue(inputValue);
     else if (id === 'defaultPort') setCustomContainerPort(inputValue);
+  };
+
+  const generateRandomLocalPort = () => {
+    const usedPorts = new Set(portForwardingList.map(({ localPort }) => localPort));
+    let randomPort = 0;
+    do {
+      randomPort = RANDOM_LOCAL_PORT_MIN + Math.floor(Math.random() * (RANDOM_LOCAL_PORT_MAX - RANDOM_LOCAL_PORT_MIN + 1));
+    } while (usedPorts.has(randomPort));
+    setValue(String(randomPort));
   };
 
   const savePortForwarding = () => {
@@ -171,6 +183,23 @@ export function PortForwardingDialog({
               onChange={handleChange}
               value={value}
             />
+            <TooltipProvider>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="h-9 shrink-0 gap-1.5 px-3 text-xs font-normal text-muted-foreground"
+                    onClick={generateRandomLocalPort}
+                  >
+                    <Dices className="h-4 w-4" />
+                    Random
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  Pick a random unused port
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
           <div className="flex items-center gap-2">
             <label className="font-medium text-foreground">
@@ -210,7 +239,7 @@ export function PortForwardingDialog({
             </div>
           )}
           <div className="mt-2 flex items-center gap-2">
-            <span className="text-sm">Set the local port to <strong>0</strong> to allow Kubernetes to assign a random port automatically.</span>
+            <span className="text-sm">Use <strong>Random</strong> to pick an unused port, or set the local port to <strong>0</strong> to let Kubernetes assign one automatically.</span>
           </div>
           {filteredList.length > 0 && (
             <div>

--- a/client/src/components/app/Table/data-table.tsx
+++ b/client/src/components/app/Table/data-table.tsx
@@ -54,6 +54,7 @@ type DataTableProps<TData, TValue> = {
   instanceType: string;
   kind?: string;
   showToolbar?: boolean;
+  emptyMessage?: string;
   loading?: boolean;
   showChat: boolean;
   setShowChat: React.Dispatch<React.SetStateAction<boolean>>;
@@ -110,6 +111,7 @@ export function DataTable<TData, TValue>({
   instanceType,
   kind,
   showToolbar = true,
+  emptyMessage,
   loading = false,
   setShowChat,
   showChat
@@ -260,7 +262,7 @@ export function DataTable<TData, TValue>({
                 collapse to the header row, squeezing the message under it. */}
             <div
               ref={tableContainerRef}
-              className={cn('border border-x-0 overflow-auto', tableWidthCss, !rows.length && 'min-h-40')}
+              className={cn('relative border border-x-0 overflow-auto', tableWidthCss, !rows.length && 'min-h-40')}
             >
               <TooltipProvider delayDuration={0}>
               <Table style={{ tableLayout: 'fixed' }}>
@@ -366,7 +368,7 @@ export function DataTable<TData, TValue>({
                         </div>
                       </>
                     ) : (
-                      <p className="text-sm text-muted-foreground">No {getSearchTarget(instanceType, kind)} found in cluster.</p>
+                      <p className="text-sm text-muted-foreground">{emptyMessage ?? `No ${getSearchTarget(instanceType, kind)} found in cluster.`}</p>
                     )}
                   </div>
                 </div>

--- a/client/src/components/app/Table/data-table.tsx
+++ b/client/src/components/app/Table/data-table.tsx
@@ -32,6 +32,7 @@ import { RootState } from "@/redux/store";
 import { Separator } from '@/components/ui/separator';
 import { TableDelete } from './TableDelete';
 import { useFittedColumnWidths } from "@/hooks/use-fitted-column-widths";
+import { resetFilterNamespace } from "@/data/Misc/ListTableNamesapceSlice";
 import { resetListTableFilter } from "@/data/Misc/ListTableFilterSlice";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -80,6 +81,12 @@ const lowerNeedle = (value: string) => {
   return lastNeedleLower;
 };
 
+const describeNamespaces = (namespaces: string[]) => {
+  if (namespaces.length === 1) return `namespace "${namespaces[0]}"`;
+  if (namespaces.length === 2) return `namespaces "${namespaces[0]}" and "${namespaces[1]}"`;
+  return `${namespaces.length} selected namespaces`;
+};
+
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
   const rowValue = row.getValue(columnId);
@@ -116,22 +123,21 @@ export function DataTable<TData, TValue>({
     selectedNamespace
   } = useAppSelector((state: RootState) => state.listTableNamesapce);
 
-  const getDefaultValue = () => {
-    if (selectedNamespace.length > 0) {
-      return [{
-        id: 'Namespace',
-        value: Array.from(selectedNamespace)
-      }];
-    }
-    return [];
-  };
+  const followsToolbarFilters = showToolbar;
+  const initialColumnFilters: ColumnFiltersState =
+    followsToolbarFilters && selectedNamespace.length > 0
+      ? [{ id: 'Namespace', value: [...selectedNamespace] }]
+      : [];
+
   const [rowSelection, setRowSelection] = useState({});
-  const [globalFilter, setGlobalFilter] = useState(searchString);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(getDefaultValue());
+  const [globalFilter, setGlobalFilter] = useState(followsToolbarFilters ? searchString : '');
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(initialColumnFilters);
 
   useEffect(() => {
-    setGlobalFilter(searchString);
-  }, [searchString]);
+    if (followsToolbarFilters) {
+      setGlobalFilter(searchString);
+    }
+  }, [followsToolbarFilters, searchString]);
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const table = useReactTable({
     data,
@@ -215,6 +221,17 @@ export function DataTable<TData, TValue>({
   const handleClearSearch = () => {
     setGlobalFilter('');
     dispatch(resetListTableFilter());
+  };
+
+  const namespaceColumnFilter = table.getColumn('Namespace')?.getFilterValue();
+  const filteredNamespaces = Array.isArray(namespaceColumnFilter) ? namespaceColumnFilter as string[] : [];
+  const hasSearch = !!globalFilter;
+  const hasNamespaceFilter = filteredNamespaces.length > 0;
+  const emptiedByFilters = data.length > 0 && (hasSearch || hasNamespaceFilter);
+
+  const handleClearNamespaceFilter = () => {
+    table.getColumn('Namespace')?.setFilterValue(undefined);
+    dispatch(resetFilterNamespace());
   };
 
   return (
@@ -312,18 +329,41 @@ export function DataTable<TData, TValue>({
               {!rows.length && (
                 <div className="absolute inset-x-0 top-10 bottom-0 flex items-center justify-center pointer-events-none">
                   <div className="flex flex-col items-center gap-2 text-center pointer-events-auto">
-                    {globalFilter ? (
+                    {emptiedByFilters ? (
                       <>
-                        <p>No results found for search term &quot;{globalFilter}&quot;</p>
-                        <p className="text-sm text-muted-foreground">Check the spelling, or try a shorter search term.</p>
-                        <Button
-                          variant="secondary"
-                          onClick={handleClearSearch}
-                          className="mt-1 h-8 gap-1.5 px-3"
-                        >
-                          Clear Search
-                          <X className="h-3.5 w-3.5" />
-                        </Button>
+                        {hasSearch
+                          ? <p>No results found for search term &quot;{globalFilter}&quot;{hasNamespaceFilter && ` in ${describeNamespaces(filteredNamespaces)}`}</p>
+                          : <p>No {getSearchTarget(instanceType, kind)} found in {describeNamespaces(filteredNamespaces)}</p>
+                        }
+                        <p className="text-sm text-muted-foreground">
+                          {hasSearch
+                            ? hasNamespaceFilter
+                              ? 'Check the spelling, try a shorter search term, or clear the namespace filter.'
+                              : 'Check the spelling, or try a shorter search term.'
+                            : 'Try selecting a different namespace, or clear the filter.'}
+                        </p>
+                        <div className="mt-1 flex items-center gap-2">
+                          {hasSearch && (
+                            <Button
+                              variant="secondary"
+                              onClick={handleClearSearch}
+                              className="h-8 gap-1.5 px-3"
+                            >
+                              Clear Search
+                              <X className="h-3.5 w-3.5" />
+                            </Button>
+                          )}
+                          {hasNamespaceFilter && (
+                            <Button
+                              variant="secondary"
+                              onClick={handleClearNamespaceFilter}
+                              className="h-8 gap-1.5 px-3"
+                            >
+                              Clear Namespace Filter
+                              <X className="h-3.5 w-3.5" />
+                            </Button>
+                          )}
+                        </div>
                       </>
                     ) : (
                       <p className="text-sm text-muted-foreground">No {getSearchTarget(instanceType, kind)} found in cluster.</p>

--- a/client/src/types/CustomResources/customResourcesDefinitionDetails.d.ts
+++ b/client/src/types/CustomResources/customResourcesDefinitionDetails.d.ts
@@ -1,6 +1,10 @@
+import { OwnerReference } from "../misc";
+
 type CustomResourcesDefinitionDetails = {
   metadata: {
     name: string,
+    namespace?: string,
+    ownerReferences?: (OwnerReference | null)[] | null,
     uid: string,
     resourceVersion: string,
     generation: number,

--- a/client/src/types/CustomResources/customResourcesDetails.d.ts
+++ b/client/src/types/CustomResources/customResourcesDetails.d.ts
@@ -1,3 +1,5 @@
+import { OwnerReference } from "../misc";
+
 type CustomResourceDetails = {
   apiVersion: string;
   kind: string;
@@ -9,6 +11,7 @@ type CustomResourceDetails = {
     generation: number;
     name: string;
     namespace: string;
+    ownerReferences?: (OwnerReference | null)[] | null;
     resourceVersion: number;
     uid: string;
     labels?: {

--- a/client/src/types/Networks/networkpolicies.d.ts
+++ b/client/src/types/Networks/networkpolicies.d.ts
@@ -1,3 +1,5 @@
+import { OwnerReference } from "../misc";
+
 type NetworkPoliciesHeaders = {
   namespace: string;
   name: string;
@@ -24,6 +26,7 @@ type NetworkPolicyDetailsMetadata = {
   } | null;
   name?: string | null;
   namespace?: string | null;
+  ownerReferences?: (OwnerReference | null)[] | null;
   resourceVersion?: string | null;
   uid?: string | null;
 };

--- a/client/src/types/Storages/common.d.ts
+++ b/client/src/types/Storages/common.d.ts
@@ -1,3 +1,5 @@
+import { OwnerReference } from "../misc";
+
 /**
  * The slice of ObjectMeta the storage details cards actually read. The older
  * generated types in this folder each carry a full copy of ObjectMeta; nothing
@@ -16,6 +18,8 @@ type StorageDetailsMetadata = {
     [k: string]: string | null;
   } | null;
   name?: string | null;
+  namespace?: string | null;
+  ownerReferences?: (OwnerReference | null)[] | null;
   resourceVersion?: string | null;
   uid?: string | null;
 };

--- a/client/src/types/Workloads/pod.d.ts
+++ b/client/src/types/Workloads/pod.d.ts
@@ -84,8 +84,12 @@ type PodDetailsSpec = {
   serviceAccountName: string,
   serviceAccount: string,
   nodeName: string,
+  nodeSelector?: {
+    [key: string]: string,
+  },
   schedulerName: string,
   priority: number,
+  priorityClassName?: string,
   enabledServiceLinks: boolean,
   preemptionPolicy: string,
 };

--- a/client/src/types/misc.d.ts
+++ b/client/src/types/misc.d.ts
@@ -92,6 +92,7 @@ type CustomResourcesNavigationKeys = {
     icon: string;
     name: string;
     route: string;
+    scope: string;
     additionalPrinterColumns: CustomResourcesPrinterColumns[];
   }[];
 };
@@ -108,9 +109,27 @@ type KeyValueNull = ({
   [key: string]: string | number | null
 } | null);
 
+type OwnerReference = {
+  apiVersion?: string | null;
+  kind: string;
+  name: string;
+  controller?: boolean | null;
+};
+
+type DetailsCardLink = {
+  resourcekind: string;
+  resourcename: string;
+  namespace?: string;
+  customResource?: {
+    group: string;
+    kind: string;
+  };
+};
+
 type DetailsCards = {
   label: string;
   value: string | number | true;
+  link?: DetailsCardLink;
 }[];
 
 type BadgeDetails = {
@@ -151,6 +170,8 @@ export {
   kwDetailsSearch,
   KeyValue,
   KeyValueNull,
+  OwnerReference,
+  DetailsCardLink,
   DetailsCards,
   BadgeDetails,
   CommonSearchParams

--- a/client/src/utils/DetailType/DetailDefinations.ts
+++ b/client/src/utils/DetailType/DetailDefinations.ts
@@ -1,5 +1,5 @@
 import { CSIDriverDetails, CSINodeDetails, ClusterRoleBindingDetails, ClusterRoleDetails, ConfigMapDetails, CronJobDetails, CustomResourceDetails, CustomResourcesDefinitionDetails, DaemonSetDetails, DeploymentDetails, EndpointDetails, HPADetails, IngressDetails, JobDetails, KeyValueNull, LeaseDetails, LimitRangeDetails, NamespaceDetails, NodeDetails, PersistentVolumeClaimDetails, PersistentVolumeDetails, PodDetails, PodDisruptionBudgetDetails, PriorityClassDetails, ReplicaSetDetails, ResourceQuotaDetails, RoleBindingDetails, RoleDetails, RuntimeClassDetails, SecretDetails, ServiceAccountDetails, ServiceDetails, NetworkPolicyDetails, StatefulSetDetails, StorageClassDetails, VolumeAttributesClassDetails } from "@/types";
-import { defaultOrValue, defaultOrValueObject, getAnnotationCardDetails, getLabelConditionCardDetails } from "../MiscUtils";
+import { defaultOrKeyValuePairs, defaultOrValue, defaultOrValueObject, getAnnotationCardDetails, getControlledByDetail, getLabelConditionCardDetails, getServiceAccountDetail } from "../MiscUtils";
 
 // Cluster
 
@@ -7,16 +7,17 @@ const getNodeDetailsConfig = (details: NodeDetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : details.metadata.name,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'External Id', value: defaultOrValue(details.spec.externalID) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Unschedulable', value: defaultOrValue(details.spec.unschedulable) },
     { label: 'Provider Id', value: defaultOrValue(details.spec.providerID) },
+    { label: 'External Id', value: defaultOrValue(details.spec.externalID) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -26,13 +27,14 @@ const getNamespaceDetailsConfig = (details: NamespaceDetails, loading: boolean) 
   subHeading: !details.metadata ? '' : details.metadata.name,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -42,13 +44,14 @@ const getLeaseDetailsConfig = (details: LeaseDetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -60,23 +63,26 @@ const getPodDetailsConfig = (details: PodDetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generateName) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Phase', value: defaultOrValue(details.status.phase) },
-    { label: 'HostIp', value: defaultOrValue(details.status.hostIP) },
-    { label: 'PodIp', value: defaultOrValue(details.status.podIP) },
-    { label: 'DNS Policy', value: defaultOrValue(details.spec.dnsPolicy) },
     { label: 'Node Name', value: defaultOrValue(details.spec.nodeName) },
-    { label: 'Preemption Policy', value: defaultOrValue(details.spec.preemptionPolicy) },
-    { label: 'Priority', value: defaultOrValue(details.spec.priority) },
+    { label: 'PodIp', value: defaultOrValue(details.status.podIP) },
+    { label: 'HostIp', value: defaultOrValue(details.status.hostIP) },
+    { label: 'QoS Class', value: defaultOrValue(details.status.qosClass) },
+    getServiceAccountDetail(details.spec.serviceAccountName, details.metadata.namespace),
     { label: 'Restart Policy', value: defaultOrValue(details.spec.restartPolicy) },
+    { label: 'DNS Policy', value: defaultOrValue(details.spec.dnsPolicy) },
+    { label: 'Node Selector', value: defaultOrKeyValuePairs(details.spec.nodeSelector) },
+    { label: 'Priority Class', value: defaultOrValue(details.spec.priorityClassName) },
+    { label: 'Priority', value: defaultOrValue(details.spec.priority) },
+    { label: 'Preemption Policy', value: defaultOrValue(details.spec.preemptionPolicy) },
     { label: 'Scheduler Name', value: defaultOrValue(details.spec.schedulerName) },
-    { label: 'Service Account', value: defaultOrValue(details.spec.serviceAccount) },
-    { label: 'Service Account Name', value: defaultOrValue(details.spec.serviceAccountName) },
-    { label: 'Termination GracePeriod Seconds', value: defaultOrValue(details.spec.terminationGracePeriodSeconds) }
+    { label: 'Termination GracePeriod Seconds', value: defaultOrValue(details.spec.terminationGracePeriodSeconds) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -86,23 +92,24 @@ const getDeploymentDetailsConfig = (details: DeploymentDetails, loading: boolean
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Replicas', value: defaultOrValue(details.spec.replicas) },
-    { label: 'Updated Replicas', value: defaultOrValue(details.status.updatedReplicas) },
     { label: 'Ready Replicas', value: defaultOrValue(details.status.readyReplicas) },
     { label: 'Available Replicas', value: defaultOrValue(details.status.availableReplicas) },
+    { label: 'Updated Replicas', value: defaultOrValue(details.status.updatedReplicas) },
     { label: 'Unavailable Replicas', value: defaultOrValue(details.status.unavailableReplicas) },
+    { label: 'Strategy Type', value: defaultOrValue(details.spec.strategy?.type) },
+    { label: 'Max Surge', value: defaultOrValue(details.spec.strategy?.rollingUpdate?.maxSurge) },
+    { label: 'Max Unavailable', value: defaultOrValue(details.spec.strategy?.rollingUpdate?.maxUnavailable) },
     { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
     { label: 'Progress Deadline Seconds', value: defaultOrValue(details.spec.progressDeadlineSeconds) },
     { label: 'Revision History Limit', value: defaultOrValue(details.spec.revisionHistoryLimit) },
-    { label: 'Strategy Type', value: defaultOrValue(details.spec.strategy?.type) },
-    { label: 'Max Surge', value: defaultOrValue(details.spec.strategy?.rollingUpdate?.maxSurge) },
-    { label: 'Max Unavailable', value: defaultOrValue(details.spec.strategy?.rollingUpdate?.maxUnavailable) }
+    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -112,23 +119,24 @@ const getDaemonSetDetailsConfig = (details: DaemonSetDetails, loading: boolean) 
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
-    { label: 'Current Number Scheduled', value: defaultOrValue(details.status.currentNumberScheduled) },
-    { label: 'Desired Number Scheduled', value: defaultOrValue(details.status.desiredNumberScheduled) },
-    { label: 'Number Misscheduled', value: defaultOrValue(details.status.numberMisscheduled) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Ready', value: defaultOrValue(details.status.numberReady) },
-    { label: 'Collision Count', value: defaultOrValue(details.status.collisionCount) },
-    { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
-    { label: 'Revision History Limit', value: defaultOrValue(details.spec.revisionHistoryLimit) },
+    { label: 'Desired Number Scheduled', value: defaultOrValue(details.status.desiredNumberScheduled) },
+    { label: 'Current Number Scheduled', value: defaultOrValue(details.status.currentNumberScheduled) },
+    { label: 'Number Misscheduled', value: defaultOrValue(details.status.numberMisscheduled) },
     { label: 'Update Strategy', value: defaultOrValue(details.spec.updateStrategy?.type) },
     { label: 'Max Surge', value: defaultOrValue(details.spec.updateStrategy?.rollingUpdate?.maxSurge) },
-    { label: 'Max Unavailable', value: defaultOrValue(details.spec.updateStrategy?.rollingUpdate?.maxUnavailable) }
+    { label: 'Max Unavailable', value: defaultOrValue(details.spec.updateStrategy?.rollingUpdate?.maxUnavailable) },
+    { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
+    { label: 'Revision History Limit', value: defaultOrValue(details.spec.revisionHistoryLimit) },
+    { label: 'Collision Count', value: defaultOrValue(details.status.collisionCount) },
+    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -138,19 +146,20 @@ const getStatefulSetDetailsConfig = (details: StatefulSetDetails, loading: boole
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Ready Replicas', value: defaultOrValue(details.status.readyReplicas) },
     { label: 'Desired Replicas', value: defaultOrValue(details.status.replicas) },
     { label: 'Current Replicas', value: defaultOrValue(details.status.currentReplicas) },
-    { label: 'Ready Replicas', value: defaultOrValue(details.status.readyReplicas) },
     { label: 'Available Replicas', value: defaultOrValue(details.status.availableReplicas) },
-    { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
     { label: 'Observed Replicas', value: defaultOrValue(details.spec.replicas) },
+    { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
+    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -160,19 +169,20 @@ const getReplicaSetDetailsConfig = (details: ReplicaSetDetails, loading: boolean
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
-    { label: 'Desired Replicas', value: defaultOrValue(details.status.replicas) },
-    { label: 'Fully Labeled Replicas', value: defaultOrValue(details.status.fullyLabeledReplicas) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Ready Replicas', value: defaultOrValue(details.status.readyReplicas) },
+    { label: 'Desired Replicas', value: defaultOrValue(details.status.replicas) },
     { label: 'Available Replicas', value: defaultOrValue(details.status.availableReplicas) },
-    { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
+    { label: 'Fully Labeled Replicas', value: defaultOrValue(details.status.fullyLabeledReplicas) },
     { label: 'Observed Replicas', value: defaultOrValue(details.spec.replicas) },
+    { label: 'Min. Ready Seconds', value: defaultOrValue(details.spec.minReadySeconds) },
+    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -182,23 +192,24 @@ const getJobsDetailsConfig = (details: JobDetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Active', value: defaultOrValue(details.status.active) },
-    { label: 'Completed Indexes', value: defaultOrValue(details.status.completedIndexes) },
-    { label: 'Failed', value: defaultOrValue(details.status.failed) },
-    { label: 'Failed Indexes', value: defaultOrValue(details.status.failedIndexes) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Ready', value: defaultOrValue(details.status.ready) },
+    { label: 'Active', value: defaultOrValue(details.status.active) },
+    { label: 'Failed', value: defaultOrValue(details.status.failed) },
+    { label: 'Completions', value: defaultOrValue(details.spec.completions) },
     { label: 'Parallelism', value: defaultOrValue(details.spec.parallelism) },
     { label: 'Backoff Limit', value: defaultOrValue(details.spec.backoffLimit) },
-    { label: 'Completions', value: defaultOrValue(details.spec.completions) },
-    { label: 'Completion Mode', value: defaultOrValue(details.spec.completionMode) },
     { label: 'Suspend', value: defaultOrValue(details.spec.suspend) },
-    { label: 'TTLSecondsAfterFinished', value: defaultOrValue(details.spec.ttlSecondsAfterFinished) }
+    { label: 'Completion Mode', value: defaultOrValue(details.spec.completionMode) },
+    { label: 'Completed Indexes', value: defaultOrValue(details.status.completedIndexes) },
+    { label: 'Failed Indexes', value: defaultOrValue(details.status.failedIndexes) },
+    { label: 'TTLSecondsAfterFinished', value: defaultOrValue(details.spec.ttlSecondsAfterFinished) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -208,13 +219,14 @@ const getCronJobsDetailsConfig = (details: CronJobDetails, loading: boolean) => 
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generateName) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Concurrency Policy', value: defaultOrValue(details.spec.concurrencyPolicy) },
-    { label: 'Failed Jobs History Limit', value: defaultOrValue(details.spec.failedJobsHistoryLimit) }
+    { label: 'Failed Jobs History Limit', value: defaultOrValue(details.spec.failedJobsHistoryLimit) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -225,14 +237,15 @@ const getSecretDetailsConfig = (details: SecretDetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Type', value: defaultOrValue(details.type) },
     { label: 'Immutable', value: defaultOrValue(typeof (details.immutable) === 'boolean' ? String(details.immutable) : details.immutable) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -242,13 +255,14 @@ const getConfigMapDetailsConfig = (details: ConfigMapDetails, loading: boolean) 
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Immutable', value: defaultOrValue(typeof (details.immutable) === 'boolean' ? String(details.immutable) : details.immutable) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -258,14 +272,15 @@ const getHPADetailsConfig = (details: HPADetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Minimum Replicas', value: defaultOrValue(details.spec.minReplicas) },
+    { label: 'Maximum Replicas', value: defaultOrValue(details.spec.maxReplicas) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Minimum Replicas', value: defaultOrValue(details.spec.minReplicas) },
-    { label: 'Maximum Replicas', value: defaultOrValue(details.spec.maxReplicas) }
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -275,12 +290,13 @@ const getLimitRangeDetailsConfig = (details: LimitRangeDetails, loading: boolean
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -290,12 +306,13 @@ const getResourceQuotaDetailsConfig = (details: ResourceQuotaDetails, loading: b
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -305,11 +322,13 @@ const getPriorityClassDetailsConfig = (details: PriorityClassDetails, loading: b
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -319,11 +338,13 @@ const getRuntimeClassDetailsConfig = (details: RuntimeClassDetails, loading: boo
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -333,17 +354,18 @@ const getPodDisruptionBudgetDetailsConfig = (details: PodDisruptionBudgetDetails
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation?.toString()) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Current Healthy', value: defaultOrValue(details.status.currentHealthy.toString()) },
     { label: 'Desired Healthy', value: defaultOrValue(details.status.desiredHealthy.toString()) },
     { label: 'Disruptions Allowed', value: defaultOrValue(details.status.disruptionsAllowed.toString()) },
     { label: 'Expected Pods', value: defaultOrValue(details.status.expectedPods.toString()) },
-    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration?.toString()) }
+    { label: 'Observed Generation', value: defaultOrValue(details.status.observedGeneration?.toString()) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation?.toString()) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -354,13 +376,14 @@ const getServiceAccountDetailsConfig = (details: ServiceAccountDetails, loading:
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'AutoMount Service Account Token', value: defaultOrValue(typeof (details.automountServiceAccountToken) === 'boolean' ? String(details.automountServiceAccountToken) : details.automountServiceAccountToken) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -370,13 +393,14 @@ const getRoleDetailsConfig = (details: RoleDetails, loading: boolean) => ({
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
     { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -386,16 +410,17 @@ const getRoleBindingDetailsConfig = (details: RoleBindingDetails, loading: boole
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Resource Kind', value: defaultOrValue(details.roleRef?.kind) },
+    { label: 'Group Name', value: defaultOrValue(details.roleRef?.name) },
+    { label: 'API Group', value: defaultOrValue(details.roleRef?.apiGroup) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'API Group', value: defaultOrValue(details.roleRef?.apiGroup) },
-    { label: 'Resource Kind', value: defaultOrValue(details.roleRef?.kind) },
-    { label: 'Group Name', value: defaultOrValue(details.roleRef?.name) }
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -405,13 +430,14 @@ const getClusterRoleDetailsConfig = (details: ClusterRoleDetails, loading: boole
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -421,16 +447,17 @@ const getClusterRoleBindingDetailsConfig = (details: ClusterRoleBindingDetails, 
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Resource Kind', value: defaultOrValue(details.roleRef?.kind) },
+    { label: 'Group Name', value: defaultOrValue(details.roleRef?.name) },
+    { label: 'API Group', value: defaultOrValue(details.roleRef?.apiGroup) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'API Group', value: defaultOrValue(details.roleRef?.apiGroup) },
-    { label: 'Resource Kind', value: defaultOrValue(details.roleRef?.kind) },
-    { label: 'Group Name', value: defaultOrValue(details.roleRef?.name) }
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -441,17 +468,18 @@ const getServiceDetailsConfig = (details: ServiceDetails, loading: boolean) => (
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Type', value: defaultOrValue(details.spec.type) },
     { label: 'Cluster IP', value: defaultOrValue(details.spec.clusterIP) },
-    { label: 'Session Affinity', value: defaultOrValue(details.spec.sessionAffinity) },
+    { label: 'Internal Traffic Policy', value: defaultOrValue(details.spec.internalTrafficPolicy) },
     { label: 'IP Family Policy', value: defaultOrValue(details.spec.ipFamilyPolicy) },
-    { label: 'Internal Traffic Policy', value: defaultOrValue(details.spec.internalTrafficPolicy) }
+    { label: 'Session Affinity', value: defaultOrValue(details.spec.sessionAffinity) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -461,15 +489,16 @@ const getNetworkPolicyDetailsConfig = (details: NetworkPolicyDetails, loading: b
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata?.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata?.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata?.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata?.creationTimestamp) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata?.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata?.generation) },
+    getControlledByDetail(details.metadata?.ownerReferences, details.metadata?.namespace),
     { label: 'Policy Types', value: defaultOrValueObject(details.spec?.policyTypes ?? []) },
     { label: 'Ingress Rules', value: String(details.spec?.ingress?.length ?? 0) },
-    { label: 'Egress Rules', value: String(details.spec?.egress?.length ?? 0) }
+    { label: 'Egress Rules', value: String(details.spec?.egress?.length ?? 0) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata?.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata?.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata?.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata?.annotations, details.metadata?.labels)
@@ -479,19 +508,20 @@ const getIngressDetailsConfig = (details: IngressDetails, loading: boolean) => (
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Ingress Class Name', value: defaultOrValue(details.spec.ingressClassName) },
+    { label: 'Service Name', value: defaultOrValue(details.spec.defaultBackend?.service?.name) },
+    { label: 'Port Number', value: defaultOrValue(details.spec.defaultBackend?.service?.port?.number) },
+    { label: 'Port Name', value: defaultOrValue(details.spec.defaultBackend?.service?.port?.name) },
+    { label: 'Resource Name', value: defaultOrValue(details.spec.defaultBackend?.resource?.name) },
+    { label: 'Resource Kind', value: defaultOrValue(details.spec.defaultBackend?.resource?.kind) },
+    { label: 'Resource API Group', value: defaultOrValue(details.spec.defaultBackend?.resource?.apiGroup) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Resource Name', value: defaultOrValue(details.spec.defaultBackend?.resource?.name) },
-    { label: 'Resource API Group', value: defaultOrValue(details.spec.defaultBackend?.resource?.apiGroup) },
-    { label: 'Resource Kind', value: defaultOrValue(details.spec.defaultBackend?.resource?.kind) },
-    { label: 'Service Name', value: defaultOrValue(details.spec.defaultBackend?.service?.name) },
-    { label: 'Port Name', value: defaultOrValue(details.spec.defaultBackend?.service?.port?.name) },
-    { label: 'Port Number', value: defaultOrValue(details.spec.defaultBackend?.service?.port?.number) },
-    { label: 'Ingress Class Name', value: defaultOrValue(details.spec.ingressClassName) }
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -501,12 +531,13 @@ const getEndpointDetailsConfig = (details: EndpointDetails, loading: boolean) =>
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -518,18 +549,18 @@ const getPersistentVolumeClaimDetailsConfig = (details: PersistentVolumeClaimDet
   subHeading: !details.metadata ? '' : `${details.metadata.namespace}/${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Phase', value: defaultOrValue(details.status.phase) },
+    { label: 'Storage ClassName', value: defaultOrValue(details.spec.storageClassName) },
+    { label: 'Volume Mode', value: defaultOrValue(details.spec.volumeMode) },
+    { label: 'Volume Attributes ClassName', value: defaultOrValue(details.spec.volumeAttributesClassName) },
+    { label: 'Current Volume Attributes ClassName', value: defaultOrValue(details.status.currentVolumeAttributesClassName) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Storage ClassName', value: defaultOrValue(details.spec.storageClassName) },
-    { label: 'Volume Attributes ClassName', value: defaultOrValue(details.spec.volumeAttributesClassName) },
-    { label: 'Volume Mode', value: defaultOrValue(details.spec.volumeMode) },
-    { label: 'Current Volume Attributes ClassName', value: defaultOrValue(details.status.currentVolumeAttributesClassName) },
-    { label: 'Phase', value: defaultOrValue(details.status.phase) },
-
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels, details.status.conditions)
@@ -539,19 +570,20 @@ const getPersistentVolumeDetailsConfig = (details: PersistentVolumeDetails, load
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Phase', value: defaultOrValue(details.status.phase) },
+    { label: 'Storage ClassName', value: defaultOrValue(details.spec.storageClassName) },
+    { label: 'Volume Mode', value: defaultOrValue(details.spec.volumeMode) },
+    { label: 'Reason', value: defaultOrValue(details.status.reason) },
+    { label: 'Message', value: defaultOrValue(details.status.message) },
+    { label: 'Last Phase Transition Time', value: defaultOrValue(details.status.lastPhaseTransitionTime) },
+    { label: 'Volume Attributes ClassName', value: defaultOrValue(details.spec.volumeAttributesClassName) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
-    { label: 'Storage ClassName', value: defaultOrValue(details.spec.storageClassName) },
-    { label: 'Volume Attributes ClassName', value: defaultOrValue(details.spec.volumeAttributesClassName) },
-    { label: 'Volume Mode', value: defaultOrValue(details.spec.volumeMode) },
-    { label: 'Last Phase Transition Time', value: defaultOrValue(details.status.lastPhaseTransitionTime) },
-    { label: 'Message', value: defaultOrValue(details.status.message) },
-    { label: 'Phase', value: defaultOrValue(details.status.phase) },
-    { label: 'Reason', value: defaultOrValue(details.status.reason) },
-
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -561,17 +593,18 @@ const getStorageClassDetailsConfig = (details: StorageClassDetails, loading: boo
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Provisioner', value: defaultOrValue(details.provisioner) },
+    { label: 'Reclaim Policy', value: defaultOrValue(details.reclaimPolicy) },
+    { label: 'Volume Binding Mode', value: defaultOrValue(details.volumeBindingMode) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
     { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata.deletionGracePeriodSeconds) },
     { label: 'Deletion Timestamp', value: defaultOrValue(details.metadata.deletionTimestamp) },
-    { label: 'Provisioner', value: defaultOrValue(details.provisioner) },
-    { label: 'Reclaim Policy', value: defaultOrValue(details.reclaimPolicy) },
-    { label: 'Volume Binding Mode', value: defaultOrValue(details.volumeBindingMode) }
-
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -581,20 +614,22 @@ const getCSIDriverDetailsConfig = (details: CSIDriverDetails, loading: boolean) 
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata?.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata?.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata?.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata?.creationTimestamp) },
-    { label: 'Generate Name', value: defaultOrValue(details.metadata?.generateName) },
-    { label: 'Generation', value: defaultOrValue(details.metadata?.generation) },
-    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata?.deletionGracePeriodSeconds) },
-    { label: 'Deletion Timestamp', value: defaultOrValue(details.metadata?.deletionTimestamp) },
+    getControlledByDetail(details.metadata?.ownerReferences),
     { label: 'Attach Required', value: defaultOrValue(details.spec?.attachRequired) },
     { label: 'Pod Info On Mount', value: defaultOrValue(details.spec?.podInfoOnMount) },
     { label: 'Storage Capacity', value: defaultOrValue(details.spec?.storageCapacity) },
     { label: 'FS Group Policy', value: defaultOrValue(details.spec?.fsGroupPolicy) },
-    { label: 'Requires Republish', value: defaultOrValue(details.spec?.requiresRepublish) },
     { label: 'SELinux Mount', value: defaultOrValue(details.spec?.seLinuxMount) },
-    { label: 'Volume Lifecycle Modes', value: defaultOrValueObject(details.spec?.volumeLifecycleModes ?? []) }
+    { label: 'Requires Republish', value: defaultOrValue(details.spec?.requiresRepublish) },
+    { label: 'Volume Lifecycle Modes', value: defaultOrValueObject(details.spec?.volumeLifecycleModes ?? []) },
+    { label: 'Generate Name', value: defaultOrValue(details.metadata?.generateName) },
+    { label: 'Generation', value: defaultOrValue(details.metadata?.generation) },
+    { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata?.deletionGracePeriodSeconds) },
+    { label: 'Deletion Timestamp', value: defaultOrValue(details.metadata?.deletionTimestamp) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata?.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata?.annotations, details.metadata?.labels)
@@ -604,14 +639,16 @@ const getCSINodeDetailsConfig = (details: CSINodeDetails, loading: boolean) => (
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata?.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata?.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata?.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata?.creationTimestamp) },
+    getControlledByDetail(details.metadata?.ownerReferences),
+    { label: 'Drivers', value: defaultOrValueObject(details.spec?.drivers?.map((driver) => driver?.name) ?? []) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata?.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata?.generation) },
     { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata?.deletionGracePeriodSeconds) },
     { label: 'Deletion Timestamp', value: defaultOrValue(details.metadata?.deletionTimestamp) },
-    { label: 'Drivers', value: defaultOrValueObject(details.spec?.drivers?.map((driver) => driver?.name) ?? []) }
+    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata?.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata?.annotations, details.metadata?.labels)
@@ -621,14 +658,16 @@ const getVolumeAttributesClassDetailsConfig = (details: VolumeAttributesClassDet
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata?.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata?.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata?.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata?.creationTimestamp) },
+    getControlledByDetail(details.metadata?.ownerReferences),
+    { label: 'Driver Name', value: defaultOrValue(details.driverName) },
     { label: 'Generate Name', value: defaultOrValue(details.metadata?.generateName) },
     { label: 'Generation', value: defaultOrValue(details.metadata?.generation) },
     { label: 'Deletion Grace Period Seconds', value: defaultOrValue(details.metadata?.deletionGracePeriodSeconds) },
     { label: 'Deletion Timestamp', value: defaultOrValue(details.metadata?.deletionTimestamp) },
-    { label: 'Driver Name', value: defaultOrValue(details.driverName) }
+    { label: 'Resource Version', value: defaultOrValue(details.metadata?.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata?.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata?.annotations, details.metadata?.labels)
@@ -639,10 +678,12 @@ const getCustomResourceDefinitionsDetailsConfig = (details: CustomResourcesDefin
   subHeading: !details.metadata ? '' : `${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
+    { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    getControlledByDetail(details.metadata.ownerReferences),
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)
@@ -652,11 +693,12 @@ const getCustomResourceDetailsConfig = (details: CustomResourceDetails, loading:
   subHeading: !details.metadata ? '' : `${details.metadata.namespace ? details.metadata.namespace + '/' : ''}${details.metadata.name}`,
   detailCard: [
     { label: 'Name', value: defaultOrValue(details.metadata.name) },
-    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
     { label: 'Namespace', value: defaultOrValue(details.metadata.namespace) },
-    { label: 'UID', value: defaultOrValue(details.metadata.uid) },
     { label: 'Age', value: defaultOrValue(details.metadata.creationTimestamp) },
-    { label: 'Generation', value: defaultOrValue(details.metadata.generation) }
+    getControlledByDetail(details.metadata.ownerReferences, details.metadata.namespace),
+    { label: 'Generation', value: defaultOrValue(details.metadata.generation) },
+    { label: 'Resource Version', value: defaultOrValue(details.metadata.resourceVersion) },
+    { label: 'UID', value: defaultOrValue(details.metadata.uid) }
   ],
   loading,
   ...getCommonCardConfig(details.metadata.annotations, details.metadata.labels)

--- a/client/src/utils/DetailType/DetailDefinations.ts
+++ b/client/src/utils/DetailType/DetailDefinations.ts
@@ -72,6 +72,7 @@ const getPodDetailsConfig = (details: PodDetails, loading: boolean) => ({
     { label: 'HostIp', value: defaultOrValue(details.status.hostIP) },
     { label: 'QoS Class', value: defaultOrValue(details.status.qosClass) },
     getServiceAccountDetail(details.spec.serviceAccountName, details.metadata.namespace),
+    { label: 'Service Account (deprecated)', value: defaultOrValue(details.spec.serviceAccount) },
     { label: 'Restart Policy', value: defaultOrValue(details.spec.restartPolicy) },
     { label: 'DNS Policy', value: defaultOrValue(details.spec.dnsPolicy) },
     { label: 'Node Selector', value: defaultOrKeyValuePairs(details.spec.nodeSelector) },

--- a/client/src/utils/MiscUtils.ts
+++ b/client/src/utils/MiscUtils.ts
@@ -117,7 +117,7 @@ const getOwnerLink = (owner: OwnerReference, namespace?: string | null) => {
   return {
     resourcekind: CUSTOM_RESOURCES_LIST_ENDPOINT,
     resourcename: owner.name,
-    customResource: { group: (owner.apiVersion ?? '').split('/')[0], kind: owner.kind },
+    customResource: { group: (owner.apiVersion ?? '').includes('/') ? owner.apiVersion!.split('/')[0] : '', kind: owner.kind },
     ...namespaceParam
   };
 };

--- a/client/src/utils/MiscUtils.ts
+++ b/client/src/utils/MiscUtils.ts
@@ -1,17 +1,22 @@
-import { CustomResources, CustomResourcesNavigation, KeyValue, KeyValueNull } from "@/types";
+import { CustomResources, CustomResourcesNavigation, KeyValue, KeyValueNull, OwnerReference } from "@/types";
 
-import { API_VERSION } from "@/constants";
+import { API_VERSION, CRON_JOBS_ENDPOINT, CUSTOM_RESOURCES_LIST_ENDPOINT, DAEMON_SETS_ENDPOINT, DEPLOYMENT_ENDPOINT, JOBS_ENDPOINT, NAMESPACES_ENDPOINT, NODES_ENDPOINT, PERSISTENT_VOLUMES_ENDPOINT, PERSISTENT_VOLUME_CLAIMS_ENDPOINT, PODS_ENDPOINT, REPLICA_SETS_ENDPOINT, SERVICES_ENDPOINT, SERVICE_ACCOUNTS_ENDPOINT, STATEFUL_SETS_ENDPOINT } from "@/constants";
 
 const mathFloor = (val = 0) => Math.floor(val);
+
+const NO_VALUE = '—';
 
 // A boolean is a real value, not a missing one: React renders `true` as nothing
 // at all, and `false` would otherwise take the `||` branch and read as unset.
 const defaultOrValue = (value?: string | number | boolean | null) =>
-  typeof value === 'boolean' ? String(value) : value || '—';
+  typeof value === 'boolean' ? String(value) : value || NO_VALUE;
+
+const defaultOrKeyValuePairs = (pairs?: KeyValue | null) =>
+  defaultOrValue(Object.entries(pairs ?? {}).map(([key, value]) => `${key}=${value}`).join(', '));
 
 const defaultOrValueObject = (value: object | Array<string | null> | string | unknown) => {
   if (Array.isArray(value)) {
-    return value.filter((secretValue) => !!secretValue).toString() || '—';
+    return value.filter((secretValue) => !!secretValue).toString() || NO_VALUE;
   }
   if (typeof value === 'string') {
     return value;
@@ -41,6 +46,7 @@ const formatCustomResources = (customResources: CustomResources[]) => {
         name: item.spec.names.kind,
         icon: item.spec.icon,
         route: item.queryParam,
+        scope: item.scope,
         additionalPrinterColumns: item.additionalPrinterColumns,
       });
     } else {
@@ -49,6 +55,7 @@ const formatCustomResources = (customResources: CustomResources[]) => {
           name: item.spec.names.kind,
           icon: item.spec.icon,
           route: item.queryParam,
+          scope: item.scope,
           additionalPrinterColumns: item.additionalPrinterColumns,
         }]
       };
@@ -77,6 +84,66 @@ const getLabelConditionCardDetails = (labels: null | undefined | KeyValueNull, c
   }
   return null;
 };
+
+const CONTROLLED_BY_LABEL = 'Controlled By';
+
+const detailsRouteByOwnerKind: Record<string, { resourcekind: string, namespaced: boolean }> = {
+  CronJob: { resourcekind: CRON_JOBS_ENDPOINT, namespaced: true },
+  DaemonSet: { resourcekind: DAEMON_SETS_ENDPOINT, namespaced: true },
+  Deployment: { resourcekind: DEPLOYMENT_ENDPOINT, namespaced: true },
+  Job: { resourcekind: JOBS_ENDPOINT, namespaced: true },
+  Namespace: { resourcekind: NAMESPACES_ENDPOINT, namespaced: false },
+  Node: { resourcekind: NODES_ENDPOINT, namespaced: false },
+  PersistentVolume: { resourcekind: PERSISTENT_VOLUMES_ENDPOINT, namespaced: false },
+  PersistentVolumeClaim: { resourcekind: PERSISTENT_VOLUME_CLAIMS_ENDPOINT, namespaced: true },
+  Pod: { resourcekind: PODS_ENDPOINT, namespaced: true },
+  ReplicaSet: { resourcekind: REPLICA_SETS_ENDPOINT, namespaced: true },
+  Service: { resourcekind: SERVICES_ENDPOINT, namespaced: true },
+  ServiceAccount: { resourcekind: SERVICE_ACCOUNTS_ENDPOINT, namespaced: true },
+  StatefulSet: { resourcekind: STATEFUL_SETS_ENDPOINT, namespaced: true }
+};
+
+const getOwnerLink = (owner: OwnerReference, namespace?: string | null) => {
+  const namespaceParam = namespace ? { namespace } : {};
+  const ownerRoute = detailsRouteByOwnerKind[owner.kind];
+  if (ownerRoute) {
+    return {
+      resourcekind: ownerRoute.resourcekind,
+      resourcename: owner.name,
+      ...(ownerRoute.namespaced ? namespaceParam : {})
+    };
+  }
+
+  return {
+    resourcekind: CUSTOM_RESOURCES_LIST_ENDPOINT,
+    resourcename: owner.name,
+    customResource: { group: (owner.apiVersion ?? '').split('/')[0], kind: owner.kind },
+    ...namespaceParam
+  };
+};
+
+const getControlledByDetail = (ownerReferences?: (OwnerReference | null)[] | null, namespace?: string | null) => {
+  const controller = ownerReferences?.find((owner) => owner?.controller);
+  if (!controller) {
+    return { label: CONTROLLED_BY_LABEL, value: NO_VALUE };
+  }
+
+  return {
+    label: CONTROLLED_BY_LABEL,
+    value: `${controller.kind}/${controller.name}`,
+    link: getOwnerLink(controller, namespace)
+  };
+};
+
+const getServiceAccountDetail = (serviceAccountName?: string | null, namespace?: string | null) => ({
+  label: 'Service Account',
+  value: defaultOrValue(serviceAccountName),
+  link: serviceAccountName ? {
+    resourcekind: SERVICE_ACCOUNTS_ENDPOINT,
+    resourcename: serviceAccountName,
+    ...(namespace ? { namespace } : {})
+  } : undefined
+});
 
 const getConditionsCardDetails = (conditions: undefined | null | KeyValueNull[]) => {
   return conditions?.reduce(function (result, item) {
@@ -172,6 +239,7 @@ const getDisplayTime = (ts: number): string => {
 
 export {
   createEventStreamQueryObject,
+  defaultOrKeyValuePairs,
   defaultOrValue,
   defaultOrValueObject,
   defaultSkeletonRow,
@@ -180,7 +248,9 @@ export {
   mathFloor,
   getAnnotationCardDetails,
   getConditionsCardDetails,
+  getControlledByDetail,
   getLabelConditionCardDetails,
+  getServiceAccountDetail,
   getSystemTheme,
   isIP,
   toggleValueInCollection,


### PR DESCRIPTION
This PR improves the filter for table.
- Allows easy reset of namespace filter
- Allow easy reset of search filter.

<img width="1210" height="797" alt="image" src="https://github.com/user-attachments/assets/49f96350-a58a-433f-84ab-556ef0bb946f" />

Details table will not be impacted if some filter is set.
